### PR TITLE
Decompose monolith into 6 npm workspace packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,29 +140,45 @@ The user can search by name in the Desktop sidebar or paste the resume command i
 
 ### Architecture
 - **Entry point:** `bin/autoclaude.mjs` — starts HTTP server + daemon
-- **Dashboard:** `http://localhost:3457` — single HTML page served from `src/dashboard.mjs`
+- **Dashboard:** `http://localhost:3457` — single HTML page served from `packages/server/dashboard.mjs`
 - **Data dir:** `~/.autoclaude/` (tasks.json, permissions.json, config.json, state.json, usage-history.json)
 - **Config defaults:** `config/default.json`
-- **Source files:** 15 files in `src/`
+- **Packages:** 6 packages in `packages/` (npm workspaces, `@autoclaude/*` scope)
 
-### Key Source Files
+### Package Structure
 
-| File | Purpose |
-|------|---------|
-| `bin/autoclaude.mjs` | Entry point, starts server + daemon |
-| `src/server.mjs` | HTTP server, REST API routes |
-| `src/dashboard.mjs` | Single-file HTML dashboard (CSS + JS inline) |
-| `src/index.mjs` | Daemon class, main loop (SLEEP/WAKE/WORK modes) |
-| `src/config.mjs` | Config loading/saving, deep merge, paths |
-| `src/task-queue.mjs` | Task CRUD + permission profiles |
-| `src/task-runner.mjs` | Spawns claude CLI, stream-json parsing, stats |
-| `src/scheduler.mjs` | Bed/wake/work time scheduler, mode transitions |
-| `src/credit-monitor.mjs` | claude.ai API usage scraping + CLI fallback |
-| `src/usage-monitor.mjs` | Usage history, graph data, polling |
-| `src/session-tracker.mjs` | Scans active Claude Code sessions from desktop app |
-| `src/summary.mjs` | Overnight work summary generation |
-| `src/logger.mjs` | File + console logging |
-| `src/notifier.mjs` | macOS notifications via osascript |
+| Package | Path | Purpose | Depends on |
+|---------|------|---------|------------|
+| `@autoclaude/core` | `packages/core/` | Config, logging, notifications, scheduler | nothing |
+| `@autoclaude/sessions` | `packages/sessions/` | macOS Claude Code session scanning | nothing |
+| `@autoclaude/store` | `packages/store/` | Tasks, permissions, projects, usage, summaries | core, sessions |
+| `@autoclaude/runner` | `packages/runner/` | Task runner + credit monitor (subprocess/API) | core, store |
+| `@autoclaude/server` | `packages/server/` | HTTP API, SSE, dashboard frontend | core, store, sessions |
+| `@autoclaude/daemon` | `packages/daemon/` | Orchestration loop (SLEEP/WAKE/WORK) | core, store, runner |
+
+Each package has its own `CLAUDE.md` with scope, exports, and conventions. Read the relevant package's `CLAUDE.md` when working on that area.
+
+### Key Files
+
+| File | Package | Purpose |
+|------|---------|---------|
+| `bin/autoclaude.mjs` | (root) | Entry point, wires daemon + server |
+| `packages/server/server.mjs` | server | HTTP server, REST API routes |
+| `packages/server/dashboard.mjs` | server | Single-file HTML dashboard (CSS + JS inline) |
+| `packages/daemon/index.mjs` | daemon | Daemon class, main loop (SLEEP/WAKE/WORK modes) |
+| `packages/core/config.mjs` | core | Config loading/saving, deep merge, paths |
+| `packages/store/task-queue.mjs` | store | Task CRUD + permission profiles |
+| `packages/runner/task-runner.mjs` | runner | Spawns claude CLI, stream-json parsing, stats |
+| `packages/core/scheduler.mjs` | core | Bed/wake/work time scheduler, mode transitions |
+| `packages/runner/credit-monitor.mjs` | runner | claude.ai API usage scraping + CLI fallback |
+| `packages/store/usage-monitor.mjs` | store | Usage history, graph data, polling |
+| `packages/sessions/session-tracker.mjs` | sessions | Scans active Claude Code sessions from desktop app |
+| `packages/store/summary.mjs` | store | Overnight work summary generation |
+| `packages/core/logger.mjs` | core | File + console logging |
+| `packages/core/notifier.mjs` | core | macOS notifications via osascript |
+
+### Legacy `src/` Directory
+The `src/` directory contains the original monolithic source files. They are no longer used — all source has been moved to `packages/`. The `src/` directory will be removed in a future cleanup.
 
 ### Coding Standards
 Read this CLAUDE.md before implementing changes. Follow the constraints and conventions below.
@@ -170,10 +186,11 @@ Read this CLAUDE.md before implementing changes. Follow the constraints and conv
 ## Coding Standards
 
 ### Constraints
-- **Zero npm dependencies** — Node.js 18+ built-ins only (`node:fs`, `node:http`, `node:https`, `node:path`, `node:os`, `node:child_process`, `node:crypto`, `node:url`)
+- **Zero external npm dependencies** — Node.js 18+ built-ins only (`node:fs`, `node:http`, `node:https`, `node:path`, `node:os`, `node:child_process`, `node:crypto`, `node:url`). Internal `@autoclaude/*` workspace packages are OK.
 - **ES Modules** — all files use `.mjs` extension and `import`/`export`
-- **Single HTML dashboard** — the entire frontend (HTML, CSS, JS) lives in `src/dashboard.mjs` as a template literal string
+- **Single HTML dashboard** — the entire frontend (HTML, CSS, JS) lives in `packages/server/dashboard.mjs` as a template literal string
 - **Dark theme** — all UI uses the CSS custom properties defined in `getDashboardHtml()`
+- **npm workspaces** — packages import each other via `@autoclaude/core`, `@autoclaude/store`, etc. Run `npm install` after cloning to link workspaces.
 
 ### Conventions
 - Functions use `camelCase`
@@ -354,12 +371,12 @@ Never merge without explicit user approval via the Approve button.
 - **Use plan mode for ALL approval gates** — Gate 1 (plan), Gate 2 (testing), Gate 3 (merge). Always `EnterPlanMode` → write summary to plan file → `ExitPlanMode` → wait for Approve. Never proceed past a gate without the Approve button.
 - **Never merge without Gate 3 approval** — create the PR first, then present the diff summary in plan mode for approval.
 - **Check for existing project board items** before creating new ones — avoid duplicates.
-- **Zero dependencies** — never add npm packages. Use only Node.js built-in modules.
+- **Zero external dependencies** — never add external npm packages. Use only Node.js built-in modules and internal `@autoclaude/*` workspace packages.
 - **One feature per session** — don't mix features in a single session.
 - **Bump version on every commit** — use `V.MM.PPPP` format in `package.json`. Bump PPPP on every commit, bump MM on feature merge (resets PPPP). Read the current version, bump it, write it back, and include in the commit. On feature merge, also update README.md (when it exists) and create a git tag.
 - **Push after every commit** — always `git push` immediately after each commit. Don't batch commits locally.
 - **Commit as you go** — don't batch all changes into one big commit at the end. Commit after each logical change (new file, bug fix, refactor step). All changes must be committed and pushed before entering Gate 2.
-- **Dashboard is a single file** — all HTML, CSS, and JavaScript for the frontend must remain in `src/dashboard.mjs` as a template literal.
+- **Dashboard is a single file** — all HTML, CSS, and JavaScript for the frontend must remain in `packages/server/dashboard.mjs` as a template literal.
 - **Dark theme only** — use the existing CSS custom properties (--bg, --bg2, --text, --accent, etc.) for all UI additions.
 - When in doubt, ask the user.
 

--- a/bin/autoclaude.mjs
+++ b/bin/autoclaude.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
-import { Daemon } from '../src/index.mjs';
-import { startServer, setDaemon } from '../src/server.mjs';
-import { loadConfig } from '../src/config.mjs';
-import { log } from '../src/logger.mjs';
+import { Daemon } from '@autoclaude/daemon';
+import { startServer, setDaemon } from '@autoclaude/server';
+import { loadConfig, log } from '@autoclaude/core';
 
 const config = loadConfig();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,94 @@
+{
+  "name": "autoclaude",
+  "version": "1.1.0001",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "autoclaude",
+      "version": "1.1.0001",
+      "license": "MIT",
+      "workspaces": [
+        "packages/core",
+        "packages/sessions",
+        "packages/store",
+        "packages/runner",
+        "packages/server",
+        "packages/daemon"
+      ],
+      "bin": {
+        "autoclaude": "bin/autoclaude.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@autoclaude/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@autoclaude/daemon": {
+      "resolved": "packages/daemon",
+      "link": true
+    },
+    "node_modules/@autoclaude/runner": {
+      "resolved": "packages/runner",
+      "link": true
+    },
+    "node_modules/@autoclaude/server": {
+      "resolved": "packages/server",
+      "link": true
+    },
+    "node_modules/@autoclaude/sessions": {
+      "resolved": "packages/sessions",
+      "link": true
+    },
+    "node_modules/@autoclaude/store": {
+      "resolved": "packages/store",
+      "link": true
+    },
+    "packages/core": {
+      "name": "@autoclaude/core",
+      "version": "1.0.0"
+    },
+    "packages/daemon": {
+      "name": "@autoclaude/daemon",
+      "version": "1.0.0",
+      "dependencies": {
+        "@autoclaude/core": "1.0.0",
+        "@autoclaude/runner": "1.0.0",
+        "@autoclaude/server": "1.0.0",
+        "@autoclaude/store": "1.0.0"
+      }
+    },
+    "packages/runner": {
+      "name": "@autoclaude/runner",
+      "version": "1.0.0",
+      "dependencies": {
+        "@autoclaude/core": "1.0.0",
+        "@autoclaude/store": "1.0.0"
+      }
+    },
+    "packages/server": {
+      "name": "@autoclaude/server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@autoclaude/core": "1.0.0",
+        "@autoclaude/sessions": "1.0.0",
+        "@autoclaude/store": "1.0.0"
+      }
+    },
+    "packages/sessions": {
+      "name": "@autoclaude/sessions",
+      "version": "1.0.0"
+    },
+    "packages/store": {
+      "name": "@autoclaude/store",
+      "version": "1.0.0",
+      "dependencies": {
+        "@autoclaude/core": "1.0.0",
+        "@autoclaude/sessions": "1.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoclaude",
-  "version": "1.0.0",
+  "version": "1.1.0001",
   "description": "Overnight Claude Code task runner with credit monitoring and web dashboard",
   "type": "module",
   "bin": {
@@ -9,6 +9,14 @@
   "scripts": {
     "start": "node bin/autoclaude.mjs"
   },
+  "workspaces": [
+    "packages/core",
+    "packages/sessions",
+    "packages/store",
+    "packages/runner",
+    "packages/server",
+    "packages/daemon"
+  ],
   "engines": {
     "node": ">=18.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoclaude",
-  "version": "1.1.0001",
+  "version": "1.2.0000",
   "description": "Overnight Claude Code task runner with credit monitoring and web dashboard",
   "type": "module",
   "bin": {

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1,0 +1,37 @@
+# @autoclaude/core
+
+Foundation primitives that all other packages depend on. This package has zero dependencies on other `@autoclaude/*` packages.
+
+## Scope
+
+- **Config** (`config.mjs`) — loads `config/default.json`, merges with user config at `~/.autoclaude/config.json`, resolves all file paths. Single source of truth for `paths.*`.
+- **Logger** (`logger.mjs`) — writes to log file + stderr with ANSI color. Supports listener subscriptions for SSE broadcast.
+- **Notifier** (`notifier.mjs`) — macOS notifications via `osascript`. Best-effort (errors silently ignored).
+- **Scheduler** (`scheduler.mjs`) — pure time-based SLEEP/WAKE/WORK mode calculation. Zero imports, no side effects.
+
+## Key Exports
+
+```js
+// config
+loadConfig(forceReload?) → config object
+saveConfig(updates) → config object
+getConfig(key?) → value
+
+// logger
+log(level, message)
+onLog(fn) → unsubscribe function
+getRecentLogs(lines?) → string[]
+
+// notifier
+notify(message, title?)
+
+// scheduler
+Scheduler class, MODES constant
+```
+
+## Conventions
+
+- Config paths are resolved in `config.mjs` — never hardcode `~/.autoclaude/` elsewhere
+- All data directory creation happens in `loadConfig()`
+- Logger level threshold: `debug` < `info` < `warn` < `error`. Only `info`+ goes to stderr.
+- `DEFAULTS_PATH` in config.mjs resolves to `../../config/default.json` relative to this package

--- a/packages/core/config.mjs
+++ b/packages/core/config.mjs
@@ -1,0 +1,77 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = join(homedir(), '.autoclaude');
+const CONFIG_PATH = join(DATA_DIR, 'config.json');
+const DEFAULTS_PATH = join(__dirname, '..', '..', 'config', 'default.json');
+
+let _config = null;
+
+function deepMerge(target, source) {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+      result[key] = deepMerge(result[key] || {}, source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+export function loadConfig(forceReload = false) {
+  if (_config && !forceReload) return _config;
+
+  if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+
+  const defaults = JSON.parse(readFileSync(DEFAULTS_PATH, 'utf8'));
+  let userConfig = {};
+  if (existsSync(CONFIG_PATH)) {
+    try {
+      userConfig = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+    } catch { /* use defaults */ }
+  }
+
+  _config = deepMerge(defaults, userConfig);
+
+  // Resolve paths
+  _config.paths = {
+    dataDir: DATA_DIR,
+    taskFile: join(DATA_DIR, 'tasks.json'),
+    permissionsFile: join(DATA_DIR, 'permissions.json'),
+    stateFile: join(DATA_DIR, 'state.json'),
+    logFile: join(DATA_DIR, 'autoclaude.log'),
+    usageHistoryFile: join(DATA_DIR, 'usage-history.json'),
+    projectsFile: join(DATA_DIR, 'projects.json'),
+    summaryDir: join(DATA_DIR, 'summaries'),
+  };
+
+  // Ensure directories exist
+  if (!existsSync(_config.paths.summaryDir)) {
+    mkdirSync(_config.paths.summaryDir, { recursive: true });
+  }
+
+  return _config;
+}
+
+export function saveConfig(updates) {
+  const config = loadConfig();
+  let userConfig = {};
+  if (existsSync(CONFIG_PATH)) {
+    try {
+      userConfig = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+    } catch { /* start fresh */ }
+  }
+  const merged = deepMerge(userConfig, updates);
+  writeFileSync(CONFIG_PATH, JSON.stringify(merged, null, 2));
+  _config = null; // force reload
+  return loadConfig(true);
+}
+
+export function getConfig(key) {
+  const config = loadConfig();
+  return key ? key.split('.').reduce((o, k) => o?.[k], config) : config;
+}

--- a/packages/core/index.mjs
+++ b/packages/core/index.mjs
@@ -1,0 +1,4 @@
+export { loadConfig, saveConfig, getConfig } from './config.mjs';
+export { log, onLog, getRecentLogs } from './logger.mjs';
+export { notify } from './notifier.mjs';
+export { Scheduler, MODES } from './scheduler.mjs';

--- a/packages/core/logger.mjs
+++ b/packages/core/logger.mjs
@@ -1,0 +1,41 @@
+import { appendFileSync, readFileSync, existsSync } from 'node:fs';
+import { loadConfig } from './config.mjs';
+
+const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
+const COLORS = { info: '\x1b[36m', warn: '\x1b[33m', error: '\x1b[31m', debug: '\x1b[90m' };
+
+const _listeners = [];
+
+export function log(level, message) {
+  const config = loadConfig();
+  const timestamp = new Date().toISOString();
+  const line = `[${timestamp}] [${level.toUpperCase().padEnd(5)}] ${message}`;
+
+  appendFileSync(config.paths.logFile, line + '\n');
+
+  if (LEVELS[level] >= LEVELS.info) {
+    const color = COLORS[level] || '';
+    process.stderr.write(`${color}${line}\x1b[0m\n`);
+  }
+
+  // Notify listeners (for dashboard live log)
+  for (const fn of _listeners) {
+    try { fn({ timestamp, level, message }); } catch { /* ignore */ }
+  }
+}
+
+export function onLog(fn) {
+  _listeners.push(fn);
+  return () => {
+    const idx = _listeners.indexOf(fn);
+    if (idx >= 0) _listeners.splice(idx, 1);
+  };
+}
+
+export function getRecentLogs(lines = 50) {
+  const config = loadConfig();
+  if (!existsSync(config.paths.logFile)) return [];
+  const content = readFileSync(config.paths.logFile, 'utf8');
+  const allLines = content.split('\n').filter(Boolean);
+  return allLines.slice(-lines);
+}

--- a/packages/core/notifier.mjs
+++ b/packages/core/notifier.mjs
@@ -1,0 +1,19 @@
+import { execSync } from 'node:child_process';
+import { loadConfig } from './config.mjs';
+
+export function notify(message, title = 'AutoClaude') {
+  const config = loadConfig();
+  if (!config.notifications.enabled) return;
+
+  const safeTitle = title.replace(/"/g, '\\"').replace(/'/g, "'\\''");
+  const safeMessage = message.replace(/"/g, '\\"').replace(/'/g, "'\\''");
+  const sound = config.notifications.sound;
+
+  const script = `display notification "${safeMessage}" with title "${safeTitle}"${sound ? ` sound name "${sound}"` : ''}`;
+
+  try {
+    execSync(`/usr/bin/osascript -e '${script}'`, { stdio: 'ignore', timeout: 5000 });
+  } catch {
+    // Notifications are best-effort
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@autoclaude/core",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/packages/core/scheduler.mjs
+++ b/packages/core/scheduler.mjs
@@ -1,0 +1,99 @@
+export const MODES = { SLEEP: 'SLEEP', WAKE: 'WAKE', WORK: 'WORK' };
+
+export class Scheduler {
+  constructor({ bedTime, wakeTime, workTime }) {
+    this.bedTime = this._parseTime(bedTime);
+    this.wakeTime = this._parseTime(wakeTime);
+    this.workTime = this._parseTime(workTime);
+    this.currentMode = MODES.WORK; // start in WORK until explicitly started
+    this.running = false;
+    this._listeners = [];
+  }
+
+  start() {
+    this.running = true;
+    this.currentMode = this._calculateMode();
+  }
+
+  stop() {
+    this.running = false;
+    this.currentMode = MODES.WORK;
+  }
+
+  setSchedule({ bedTime, wakeTime, workTime }) {
+    if (bedTime) this.bedTime = this._parseTime(bedTime);
+    if (wakeTime) this.wakeTime = this._parseTime(wakeTime);
+    if (workTime) this.workTime = this._parseTime(workTime);
+  }
+
+  _calculateMode() {
+    if (!this.running) return MODES.WORK;
+
+    const now = new Date();
+    const nowMins = now.getHours() * 60 + now.getMinutes();
+
+    // Handle overnight wrap: bed=23:00(1380), wake=7:00(420), work=9:00(540)
+    if (this.bedTime > this.wakeTime) {
+      // Overnight schedule
+      if (nowMins >= this.bedTime || nowMins < this.wakeTime) {
+        return MODES.SLEEP;
+      } else if (nowMins >= this.wakeTime && nowMins < this.workTime) {
+        return MODES.WAKE;
+      } else {
+        return MODES.WORK;
+      }
+    } else {
+      // Same-day schedule (unusual but supported)
+      if (nowMins >= this.bedTime && nowMins < this.wakeTime) {
+        return MODES.SLEEP;
+      } else if (nowMins >= this.wakeTime && nowMins < this.workTime) {
+        return MODES.WAKE;
+      } else {
+        return MODES.WORK;
+      }
+    }
+  }
+
+  checkTransition() {
+    if (!this.running) return this.currentMode;
+    const newMode = this._calculateMode();
+    if (newMode !== this.currentMode) {
+      const oldMode = this.currentMode;
+      this.currentMode = newMode;
+      for (const fn of this._listeners) {
+        try { fn(oldMode, newMode); } catch { /* ignore */ }
+      }
+    }
+    return this.currentMode;
+  }
+
+  onModeChange(fn) {
+    this._listeners.push(fn);
+  }
+
+  shouldStartNewTask() {
+    return this.running && this.currentMode === MODES.SLEEP;
+  }
+
+  getScheduleInfo() {
+    return {
+      bedTime: this._formatTime(this.bedTime),
+      wakeTime: this._formatTime(this.wakeTime),
+      workTime: this._formatTime(this.workTime),
+      currentMode: this.currentMode,
+      running: this.running,
+    };
+  }
+
+  _parseTime(timeStr) {
+    if (!timeStr) return 0;
+    const [h, m] = timeStr.split(':').map(Number);
+    return h * 60 + (m || 0);
+  }
+
+  _formatTime(minutes) {
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+  }
+}

--- a/packages/daemon/CLAUDE.md
+++ b/packages/daemon/CLAUDE.md
@@ -1,0 +1,41 @@
+# @autoclaude/daemon
+
+Orchestration loop — wires all packages together, owns the SLEEP/WAKE/WORK cycle, drives task execution decisions.
+
+## Scope
+
+- **Daemon** (`index.mjs`) — the `Daemon` class that runs the main loop. In SLEEP mode: polls credits, runs approved tasks in sequence. In WAKE mode: generates overnight summary. In WORK mode: idles. Broadcasts status changes for SSE.
+
+## Dependencies
+
+- `@autoclaude/core` — config, scheduler, logger, notifier
+- `@autoclaude/store` — task queue, usage recording, summary generation
+- `@autoclaude/runner` — task runner, credit monitor
+
+## Key Exports
+
+```js
+Daemon class
+  .start() / .stop()
+  .setSchedule({ bedTime, wakeTime, workTime })
+  .getStatus() → { schedule, runner, creditsAvailable, ... }
+  .getUsageData() → { current, graph, raw }
+```
+
+## Entry Point
+
+`bin/autoclaude.mjs` (in the repo root) is the process entry point. It:
+1. Creates a `Daemon` instance
+2. Calls `setDaemon(daemon)` to inject it into the server package
+3. Starts the HTTP server
+4. Handles SIGINT/SIGTERM graceful shutdown
+
+## Mode Lifecycle
+
+```
+WORK → SLEEP (bedTime) → WAKE (wakeTime) → WORK (workTime)
+```
+
+- **SLEEP**: Check credits → run next approved task → repeat
+- **WAKE**: Generate overnight summary → idle
+- **WORK**: Idle (user is working)

--- a/packages/daemon/index.mjs
+++ b/packages/daemon/index.mjs
@@ -1,0 +1,180 @@
+import { loadConfig, Scheduler, MODES, log, notify } from '@autoclaude/core';
+import { getNextApprovedTask, recordPoll, recordTaskEvent, getGraphData, getCurrentUsageSummary, generateSummary } from '@autoclaude/store';
+import { checkCredits, fetchUsageFromApi, classifyUsage, CreditStatus, TaskRunner } from '@autoclaude/runner';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export class Daemon {
+  constructor() {
+    const config = loadConfig();
+    this.scheduler = new Scheduler({
+      bedTime: config.schedule.bedTime,
+      wakeTime: config.schedule.wakeTime,
+      workTime: config.schedule.workTime,
+    });
+    this.runner = new TaskRunner();
+    this.creditsAvailable = false;
+    this.sessionStartTime = new Date();
+    this.summaryGenerated = false;
+    this._loopRunning = false;
+    this._latestUsageRaw = null;
+    this._latestUsageSummary = null;
+
+    this.scheduler.onModeChange((oldMode, newMode) => {
+      log('info', `Mode transition: ${oldMode} -> ${newMode}`);
+      notify(`AutoClaude mode: ${newMode}`);
+    });
+  }
+
+  start() {
+    this.scheduler.start();
+    this.summaryGenerated = false;
+    this.sessionStartTime = new Date();
+    log('info', `Daemon started. Schedule: bed=${this.scheduler.getScheduleInfo().bedTime} wake=${this.scheduler.getScheduleInfo().wakeTime} work=${this.scheduler.getScheduleInfo().workTime}`);
+    notify('AutoClaude started. Monitoring for credits...');
+    if (!this._loopRunning) this._runLoop();
+  }
+
+  stop() {
+    this.scheduler.stop();
+    this.runner.kill();
+    log('info', 'Daemon stopped.');
+    notify('AutoClaude stopped.');
+  }
+
+  setSchedule({ bedTime, wakeTime, workTime }) {
+    this.scheduler.setSchedule({ bedTime, wakeTime, workTime });
+  }
+
+  getStatus() {
+    return {
+      schedule: this.scheduler.getScheduleInfo(),
+      runner: this.runner.getStatus(),
+      creditsAvailable: this.creditsAvailable,
+      sessionStartTime: this.sessionStartTime.toISOString(),
+      summaryGenerated: this.summaryGenerated,
+    };
+  }
+
+  getUsageData() {
+    return {
+      current: this._latestUsageSummary,
+      graph: getGraphData(12),
+      raw: this._latestUsageRaw,
+    };
+  }
+
+  async _runLoop() {
+    this._loopRunning = true;
+    const config = loadConfig();
+
+    while (true) {
+      // Check mode transitions
+      this.scheduler.checkTransition();
+      const mode = this.scheduler.currentMode;
+
+      if (!this.scheduler.running) {
+        await sleep(2000);
+        continue;
+      }
+
+      if (mode === MODES.SLEEP) {
+        await this._sleepMode(config);
+      } else if (mode === MODES.WAKE) {
+        await this._wakeMode();
+      } else {
+        // WORK mode - just idle
+        await sleep(10000);
+      }
+    }
+  }
+
+  async _sleepMode(config) {
+    if (this.runner.isRunning) {
+      await sleep(5000);
+      return;
+    }
+
+    // Poll for credits
+    log('debug', 'Checking credit availability...');
+
+    // Try API-based check first
+    const apiData = await fetchUsageFromApi();
+    if (apiData?.usage) {
+      this._latestUsageRaw = apiData;
+      this._latestUsageSummary = getCurrentUsageSummary(apiData);
+      recordPoll(apiData);
+
+      const result = classifyUsage(apiData);
+
+      if (result.status === CreditStatus.AVAILABLE) {
+        if (!this.creditsAvailable) {
+          log('info', `Credits available! ${result.detail}`);
+          notify('Credits available! Starting tasks...');
+          this.creditsAvailable = true;
+        }
+
+        const task = getNextApprovedTask();
+        if (task) {
+          recordTaskEvent('task_start', task.title);
+          await this.runner.runTask(task);
+          recordTaskEvent('task_complete', task.title);
+        } else {
+          log('info', 'All approved tasks completed. Waiting...');
+          await sleep(config.creditCheck.pollIntervalMs * 2);
+        }
+      } else {
+        this.creditsAvailable = false;
+        log('info', `Credits: ${result.status} - ${result.detail}`);
+        const waitMs = result.status === CreditStatus.RATE_LIMITED ? 60000 : config.creditCheck.pollIntervalMs;
+        await sleep(waitMs);
+      }
+    } else {
+      // Fallback to CLI check
+      const result = await checkCredits();
+      if (result.status === CreditStatus.AVAILABLE) {
+        if (!this.creditsAvailable) {
+          log('info', 'Credits available (CLI check)!');
+          notify('Credits available!');
+          this.creditsAvailable = true;
+        }
+        const task = getNextApprovedTask();
+        if (task) {
+          recordTaskEvent('task_start', task.title);
+          await this.runner.runTask(task);
+          recordTaskEvent('task_complete', task.title);
+        } else {
+          await sleep(config.creditCheck.pollIntervalMs * 2);
+        }
+      } else {
+        this.creditsAvailable = false;
+        log('info', `Credits: ${result.status} - ${result.detail}`);
+        await sleep(config.creditCheck.pollIntervalMs);
+      }
+    }
+  }
+
+  async _wakeMode() {
+    if (this.runner.isRunning) {
+      log('info', 'WAKE mode: waiting for current task to finish...');
+      await sleep(5000);
+      return;
+    }
+
+    if (!this.summaryGenerated) {
+      log('info', 'Generating overnight work summary...');
+      try {
+        const { path } = generateSummary(this.sessionStartTime);
+        log('info', `Summary written to: ${path}`);
+        notify('Overnight work summary ready!');
+      } catch (err) {
+        log('error', `Summary generation failed: ${err.message}`);
+      }
+      this.summaryGenerated = true;
+    }
+
+    await sleep(30000);
+  }
+}

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@autoclaude/daemon",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs",
+  "dependencies": {
+    "@autoclaude/core": "1.0.0",
+    "@autoclaude/store": "1.0.0",
+    "@autoclaude/runner": "1.0.0",
+    "@autoclaude/server": "1.0.0"
+  }
+}

--- a/packages/runner/CLAUDE.md
+++ b/packages/runner/CLAUDE.md
@@ -1,0 +1,38 @@
+# @autoclaude/runner
+
+Subprocess execution — spawns the `claude` CLI for task execution and checks credit availability via the claude.ai API.
+
+## Scope
+
+- **Task Runner** (`task-runner.mjs`) — spawns `claude` CLI as child process with permission profile args, budget cap, sub-agent level instruction. Parses `--output-format stream-json` for progress tracking. Handles task timeout watchdog, stats extraction, and credit-issue retry detection.
+- **Credit Monitor** (`credit-monitor.mjs`) — primary: HTTP GET to `claude.ai/api/organizations/{orgId}/usage` using session cookie. Fallback: spawns `claude` CLI with a "PONG" ping prompt. Classifies usage into `CreditStatus` enum.
+
+## Dependencies
+
+- `@autoclaude/core` — config, logger, notifier
+- `@autoclaude/store` — `updateTask`, `getPermissionProfile`
+
+## Key Exports
+
+```js
+// Task Runner
+TaskRunner class
+  .runTask(task) → Promise<{ exitCode, sessionId, duration, stats }>
+  .kill()
+  .getStatus() → { isRunning, currentTask, currentSessionId, currentDir }
+
+// Credit Monitor
+CreditStatus enum
+fetchUsageFromApi() → Promise<ApiData | null>
+classifyUsage(usageData) → { status, detail, resetsAt }
+checkCredits() → Promise<{ status, detail, source }>
+```
+
+## Key Implementation Details
+
+- `CLAUDECODE` env var is stripped before spawning claude processes
+- `--no-session-persistence` used for credit check pings
+- `--output-format stream-json` used for task execution
+- Sub-agent level (0-1 slider) maps to `--append-system-prompt` instructions
+- Watchdog kills tasks after `config.claude.taskTimeoutMs` of inactivity
+- Credit-issue failures (rate limit, billing) auto-retry by resetting task to `pending`

--- a/packages/runner/credit-monitor.mjs
+++ b/packages/runner/credit-monitor.mjs
@@ -1,0 +1,207 @@
+import { spawn } from 'node:child_process';
+import { request } from 'node:https';
+import { loadConfig, log } from '@autoclaude/core';
+
+export const CreditStatus = {
+  AVAILABLE: 'AVAILABLE',
+  RATE_LIMITED: 'RATE_LIMITED',
+  NO_CREDITS: 'NO_CREDITS',
+  API_OVERLOADED: 'API_OVERLOADED',
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  TIMEOUT: 'TIMEOUT',
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+};
+
+// Primary: scrape claude.ai usage API
+export async function fetchUsageFromApi() {
+  const config = loadConfig();
+  const { orgId, sessionKey, baseUrl } = config.claudeApi;
+
+  if (!orgId || !sessionKey) {
+    return null; // not configured, use fallback
+  }
+
+  const endpoints = {
+    usage: `/api/organizations/${orgId}/usage`,
+    overage: `/api/organizations/${orgId}/overage_spend_limit`,
+    credits: `/api/organizations/${orgId}/prepaid/credits`,
+  };
+
+  const results = {};
+  for (const [key, path] of Object.entries(endpoints)) {
+    try {
+      results[key] = await httpGet(baseUrl + path, sessionKey);
+    } catch (err) {
+      log('warn', `Failed to fetch ${key}: ${err.message}`);
+      results[key] = null;
+    }
+  }
+
+  return results;
+}
+
+function httpGet(url, sessionKey) {
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(url);
+    const options = {
+      hostname: parsedUrl.hostname,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: 'GET',
+      headers: {
+        'Cookie': `sessionKey=${sessionKey}`,
+        'Accept': 'application/json',
+        'User-Agent': 'AutoClaude/1.0',
+      },
+      timeout: 15000,
+    };
+
+    const req = request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        if (res.statusCode === 200) {
+          try {
+            resolve(JSON.parse(data));
+          } catch {
+            reject(new Error(`Invalid JSON from ${parsedUrl.pathname}`));
+          }
+        } else if (res.statusCode === 401 || res.statusCode === 403) {
+          reject(new Error(`Auth failed (${res.statusCode}) - sessionKey may have expired`));
+        } else {
+          reject(new Error(`HTTP ${res.statusCode} from ${parsedUrl.pathname}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('Request timed out')); });
+    req.end();
+  });
+}
+
+// Classify credit status from API usage data
+export function classifyUsage(usageData) {
+  const config = loadConfig();
+  const threshold = config.creditCheck.utilizationThreshold;
+
+  if (!usageData?.usage?.five_hour) {
+    return { status: CreditStatus.UNKNOWN_ERROR, detail: 'No usage data' };
+  }
+
+  const fiveHr = usageData.usage.five_hour;
+  const sevenDay = usageData.usage.seven_day;
+
+  if (fiveHr.utilization >= 100) {
+    return {
+      status: CreditStatus.NO_CREDITS,
+      detail: `5hr window: ${fiveHr.utilization}% used, resets at ${fiveHr.resets_at}`,
+      resetsAt: fiveHr.resets_at,
+    };
+  }
+
+  if (sevenDay && sevenDay.utilization >= 100) {
+    return {
+      status: CreditStatus.NO_CREDITS,
+      detail: `Weekly limit: ${sevenDay.utilization}% used, resets at ${sevenDay.resets_at}`,
+      resetsAt: sevenDay.resets_at,
+    };
+  }
+
+  if (fiveHr.utilization >= threshold) {
+    return {
+      status: CreditStatus.RATE_LIMITED,
+      detail: `5hr window: ${fiveHr.utilization}% (above ${threshold}% threshold)`,
+      resetsAt: fiveHr.resets_at,
+    };
+  }
+
+  return {
+    status: CreditStatus.AVAILABLE,
+    detail: `5hr: ${fiveHr.utilization}%, 7day: ${sevenDay?.utilization ?? '?'}%`,
+    resetsAt: fiveHr.resets_at,
+  };
+}
+
+// Combined check: try API first, fall back to CLI ping
+export async function checkCredits() {
+  // Try API first
+  const apiData = await fetchUsageFromApi();
+  if (apiData?.usage) {
+    const result = classifyUsage(apiData);
+    return { ...result, source: 'api', raw: apiData };
+  }
+
+  // Fallback: CLI ping
+  log('info', 'API unavailable, falling back to CLI credit check');
+  return checkCreditsViaCli();
+}
+
+// Fallback: spawn claude CLI to test credit availability
+function checkCreditsViaCli() {
+  const config = loadConfig();
+  const { binary } = config.claude;
+  const { pingPrompt, maxBudgetUsd, timeoutMs } = config.creditCheck;
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let resolved = false;
+
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+
+    const proc = spawn(binary, [
+      '-p', pingPrompt,
+      '--max-budget-usd', String(maxBudgetUsd),
+      '--output-format', 'text',
+      '--no-session-persistence',
+    ], {
+      env,
+      cwd: process.env.HOME,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    proc.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+
+    const timer = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        proc.kill('SIGTERM');
+        resolve({ status: CreditStatus.TIMEOUT, detail: 'CLI ping timed out', source: 'cli' });
+      }
+    }, timeoutMs);
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (resolved) return;
+      resolved = true;
+
+      if (code === 0 && stdout.trim().length > 0) {
+        resolve({ status: CreditStatus.AVAILABLE, detail: 'CLI ping succeeded', source: 'cli' });
+        return;
+      }
+
+      const combined = (stderr + stdout).toLowerCase();
+      if (/rate.?limit|429|too many requests/.test(combined)) {
+        resolve({ status: CreditStatus.RATE_LIMITED, detail: stderr.slice(0, 200), source: 'cli' });
+      } else if (/credit|billing|payment|insufficient|quota/.test(combined)) {
+        resolve({ status: CreditStatus.NO_CREDITS, detail: stderr.slice(0, 200), source: 'cli' });
+      } else if (/overloaded|503|529|capacity/.test(combined)) {
+        resolve({ status: CreditStatus.API_OVERLOADED, detail: stderr.slice(0, 200), source: 'cli' });
+      } else if (/network|econnrefused|etimedout|enotfound/.test(combined)) {
+        resolve({ status: CreditStatus.NETWORK_ERROR, detail: stderr.slice(0, 200), source: 'cli' });
+      } else {
+        resolve({ status: CreditStatus.UNKNOWN_ERROR, detail: stderr.slice(0, 200), source: 'cli' });
+      }
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      if (!resolved) {
+        resolved = true;
+        resolve({ status: CreditStatus.NETWORK_ERROR, detail: err.message, source: 'cli' });
+      }
+    });
+  });
+}

--- a/packages/runner/index.mjs
+++ b/packages/runner/index.mjs
@@ -1,0 +1,2 @@
+export { TaskRunner } from './task-runner.mjs';
+export { CreditStatus, fetchUsageFromApi, classifyUsage, checkCredits } from './credit-monitor.mjs';

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@autoclaude/runner",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs",
+  "dependencies": {
+    "@autoclaude/core": "1.0.0",
+    "@autoclaude/store": "1.0.0"
+  }
+}

--- a/packages/runner/task-runner.mjs
+++ b/packages/runner/task-runner.mjs
@@ -1,0 +1,233 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { loadConfig, log, notify } from '@autoclaude/core';
+import { updateTask, getPermissionProfile } from '@autoclaude/store';
+
+const SUBAGENT_PROMPTS = {
+  0: 'Do all work yourself. Do not use the Task tool to spawn sub-agents.',
+  0.25: 'Only use sub-agents for simple file searches and exploration.',
+  0.5: 'Use sub-agents for research, exploration, and independent subtasks.',
+  0.75: 'Maximize use of sub-agents. Delegate implementation, testing, and research to parallel agents wherever possible.',
+  1: 'Offload as much work as reasonably possible to sub-agents. Use them for all exploration, implementation, testing, and validation. Only coordinate and review their output yourself.',
+};
+
+function getSubagentPrompt(level) {
+  // Find closest defined level
+  const levels = Object.keys(SUBAGENT_PROMPTS).map(Number).sort((a, b) => a - b);
+  let closest = levels[0];
+  for (const l of levels) {
+    if (Math.abs(l - level) < Math.abs(closest - level)) closest = l;
+  }
+  return SUBAGENT_PROMPTS[closest];
+}
+
+export class TaskRunner {
+  constructor() {
+    this.currentProcess = null;
+    this.currentTask = null;
+    this.isRunning = false;
+    this._streamData = [];
+  }
+
+  async runTask(task) {
+    const config = loadConfig();
+    const sessionId = randomUUID();
+
+    this.currentTask = { ...task, sessionId };
+    this.isRunning = true;
+    this._streamData = [];
+
+    log('info', `Starting task: "${task.title}" in ${task.dir}`);
+    log('info', `Session ID: ${sessionId}`);
+    notify(`Starting task: ${task.title}`);
+
+    updateTask(task.id, {
+      status: 'running',
+      started: new Date().toISOString(),
+      sessionId,
+    });
+
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+
+    const args = ['-p', task.prompt, '--session-id', sessionId, '--output-format', 'stream-json'];
+
+    // Apply permission profile
+    const profile = getPermissionProfile(task.permissionProfile);
+    if (profile) {
+      if (profile.dangerouslySkipPermissions) {
+        args.push('--dangerously-skip-permissions');
+      } else if (profile.permissionMode) {
+        args.push('--permission-mode', profile.permissionMode);
+      }
+      if (profile.allowedTools?.length) {
+        args.push('--allowedTools', profile.allowedTools.join(' '));
+      }
+      if (profile.disallowedTools?.length) {
+        args.push('--disallowedTools', profile.disallowedTools.join(' '));
+      }
+    } else {
+      args.push('--dangerously-skip-permissions');
+    }
+
+    // Apply budget cap
+    if (config.claude.maxBudgetPerTaskUsd) {
+      args.push('--max-budget-usd', String(config.claude.maxBudgetPerTaskUsd));
+    }
+
+    // Apply sub-agent level instruction
+    const subagentPrompt = getSubagentPrompt(task.subagentLevel ?? 0.5);
+    args.push('--append-system-prompt', subagentPrompt);
+
+    const startTime = Date.now();
+
+    return new Promise((resolve) => {
+      let stdout = '';
+      let stderr = '';
+      let lastActivity = Date.now();
+
+      this.currentProcess = spawn(config.claude.binary, args, {
+        env,
+        cwd: task.dir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      this.currentProcess.stdout.on('data', (chunk) => {
+        const text = chunk.toString();
+        stdout += text;
+        lastActivity = Date.now();
+
+        // Parse stream-json lines for progress tracking
+        for (const line of text.split('\n').filter(Boolean)) {
+          try {
+            const msg = JSON.parse(line);
+            this._streamData.push(msg);
+            if (msg.type === 'assistant' && msg.subtype === 'tool_use') {
+              log('debug', `  Tool: ${msg.tool_name}`);
+            }
+          } catch { /* not all lines are valid JSON */ }
+        }
+      });
+
+      this.currentProcess.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+        lastActivity = Date.now();
+      });
+
+      // Watchdog: kill if no output for taskTimeoutMs
+      const watchdog = setInterval(() => {
+        if (Date.now() - lastActivity > config.claude.taskTimeoutMs) {
+          log('warn', `Task "${task.title}" timed out after ${config.claude.taskTimeoutMs}ms inactivity`);
+          this.currentProcess.kill('SIGTERM');
+          clearInterval(watchdog);
+        }
+      }, 60000);
+
+      this.currentProcess.on('close', (code) => {
+        clearInterval(watchdog);
+        this.isRunning = false;
+        this.currentProcess = null;
+
+        const duration = Date.now() - startTime;
+        const stats = this._extractStats();
+
+        if (code === 0) {
+          log('info', `Task "${task.title}" completed in ${Math.round(duration / 1000)}s`);
+          notify(`Task completed: ${task.title}`);
+          updateTask(task.id, {
+            status: 'completed',
+            completed: new Date().toISOString(),
+            stats,
+          });
+        } else {
+          // Check if it's a credit issue (should retry)
+          const combined = (stderr + stdout).toLowerCase();
+          const isCreditIssue = /rate.?limit|credit|billing|quota|429/.test(combined);
+
+          log('error', `Task "${task.title}" failed (exit ${code})${isCreditIssue ? ' - credit issue, will retry' : ''}`);
+          notify(`Task failed: ${task.title}`);
+          updateTask(task.id, {
+            status: isCreditIssue ? 'pending' : 'failed',
+            completed: isCreditIssue ? null : new Date().toISOString(),
+            error: stderr.slice(-300),
+            stats,
+          });
+        }
+
+        resolve({ exitCode: code, sessionId, duration, stats });
+      });
+
+      this.currentProcess.on('error', (err) => {
+        clearInterval(watchdog);
+        this.isRunning = false;
+        this.currentProcess = null;
+        log('error', `Failed to spawn Claude for "${task.title}": ${err.message}`);
+        updateTask(task.id, { status: 'failed', error: err.message });
+        resolve({ exitCode: -1, sessionId, duration: 0, stats: null });
+      });
+    });
+  }
+
+  _extractStats() {
+    const toolUses = {};
+    const subagentCalls = [];
+    const models = new Set();
+
+    for (const msg of this._streamData) {
+      // Track model usage
+      if (msg.model) models.add(msg.model);
+
+      // Track tool usage
+      if (msg.type === 'assistant') {
+        const content = msg.message?.content || [];
+        for (const block of content) {
+          if (block.type === 'tool_use') {
+            const name = block.name || 'unknown';
+            toolUses[name] = (toolUses[name] || 0) + 1;
+
+            // Track sub-agent calls specifically
+            if (name === 'Task') {
+              const input = block.input || {};
+              subagentCalls.push({
+                description: input.description || '',
+                subagentType: input.subagent_type || input.subagentType || 'unknown',
+                model: input.model || 'inherited',
+              });
+            }
+          }
+        }
+      }
+    }
+
+    const totalToolUses = Object.values(toolUses).reduce((a, b) => a + b, 0);
+    const subagentCount = subagentCalls.length;
+
+    return {
+      toolUses,
+      totalToolUses,
+      subagentCalls,
+      subagentCount,
+      models: [...models],
+      claudeDirectWork: totalToolUses - subagentCount,
+      subagentRatio: totalToolUses > 0 ? subagentCount / totalToolUses : 0,
+    };
+  }
+
+  kill() {
+    if (this.currentProcess) {
+      this.currentProcess.kill('SIGTERM');
+      setTimeout(() => {
+        if (this.currentProcess) this.currentProcess.kill('SIGKILL');
+      }, 5000);
+    }
+  }
+
+  getStatus() {
+    return {
+      isRunning: this.isRunning,
+      currentTask: this.currentTask?.title || null,
+      currentSessionId: this.currentTask?.sessionId || null,
+      currentDir: this.currentTask?.dir || null,
+    };
+  }
+}

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -1,0 +1,44 @@
+# @autoclaude/server
+
+HTTP API layer and the single-file dashboard frontend.
+
+## Scope
+
+- **Server** (`server.mjs`) — HTTP server handling all REST API routes. Serves dashboard at `/`, API at `/api/*`. Receives daemon reference via `setDaemon()` injection to avoid circular imports.
+- **Dashboard** (`dashboard.mjs`) — exports `getDashboardHtml()` which returns the entire frontend as a single HTML string (HTML, CSS, JS inline). Dark theme using CSS custom properties.
+
+## Dependencies
+
+- `@autoclaude/core` — config, saveConfig, logger
+- `@autoclaude/store` — all CRUD functions for tasks, permissions, projects, summary
+- `@autoclaude/sessions` — `scanActiveSessions`
+
+## API Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | Dashboard HTML |
+| GET/POST | `/api/tasks` | List / create tasks |
+| PUT | `/api/tasks/reorder` | Reorder tasks |
+| PUT/DELETE | `/api/tasks/:id` | Update / delete task |
+| GET/POST | `/api/permissions` | List / create profiles |
+| PUT/DELETE | `/api/permissions/:key` | Update / delete profile |
+| GET/POST | `/api/projects` | List / create projects |
+| GET/PUT/DELETE | `/api/projects/:id` | Get / update / delete project |
+| GET | `/api/status` | Daemon status |
+| POST | `/api/schedule` | Update schedule |
+| POST | `/api/daemon/start` | Start daemon |
+| POST | `/api/daemon/stop` | Stop daemon |
+| GET | `/api/sessions` | Active Claude sessions |
+| GET | `/api/usage` | Usage data |
+| POST | `/api/auth/callback` | Save session cookie |
+| GET/POST | `/api/config` | Read / update config |
+| GET | `/api/log` | Recent log lines |
+| GET | `/api/summary` | Latest overnight summary |
+
+## Conventions
+
+- All UI stays in `dashboard.mjs` as a template literal (single-file frontend)
+- Dark theme: use CSS custom properties (--bg, --bg2, --text, --accent, etc.)
+- CORS enabled for all origins
+- `setDaemon()` must be called from bin/autoclaude.mjs before server starts handling requests

--- a/packages/server/dashboard.mjs
+++ b/packages/server/dashboard.mjs
@@ -1,0 +1,1426 @@
+export function getDashboardHtml() {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AutoClaude Dashboard</title>
+<style>
+  :root {
+    --bg: #0d1117; --bg2: #161b22; --bg3: #21262d; --bg4: #30363d;
+    --text: #e6edf3; --text2: #8b949e; --text3: #484f58;
+    --accent: #58a6ff; --green: #3fb950; --red: #f85149;
+    --orange: #d29922; --purple: #bc8cff;
+    --border: #30363d; --radius: 8px;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, sans-serif; background: var(--bg); color: var(--text); line-height: 1.5; }
+
+  /* Header */
+  .header { background: var(--bg2); border-bottom: 1px solid var(--border); padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; }
+  .header-left { display: flex; align-items: center; gap: 16px; }
+  .header h1 { font-size: 18px; font-weight: 600; }
+  .status-badge { display: inline-flex; align-items: center; gap: 6px; padding: 4px 12px; border-radius: 20px; font-size: 13px; font-weight: 500; }
+  .status-badge .dot { width: 8px; height: 8px; border-radius: 50%; }
+  .status-SLEEP { background: #1a3a2a; color: var(--green); }
+  .status-SLEEP .dot { background: var(--green); }
+  .status-WAKE { background: #3a2a1a; color: var(--orange); }
+  .status-WAKE .dot { background: var(--orange); }
+  .status-WORK { background: #1a2a3a; color: var(--accent); }
+  .status-WORK .dot { background: var(--accent); }
+  .header-controls { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+  .time-input { display: flex; align-items: center; gap: 4px; font-size: 13px; color: var(--text2); }
+  .time-input input[type="text"] { width: 58px; background: var(--bg3); border: 1px solid var(--border); color: var(--text); padding: 4px 6px; border-radius: 4px; font-size: 13px; text-align: center; font-family: 'SF Mono', Monaco, monospace; letter-spacing: 1px; }
+  .btn { padding: 6px 16px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg3); color: var(--text); cursor: pointer; font-size: 13px; font-weight: 500; transition: all 0.15s; }
+  .btn:hover { background: var(--bg4); }
+  .btn-primary { background: var(--green); border-color: var(--green); color: #000; }
+  .btn-primary:hover { opacity: 0.9; }
+  .btn-danger { background: var(--red); border-color: var(--red); color: #fff; }
+  .btn-danger:hover { opacity: 0.9; }
+  .btn-sm { padding: 3px 10px; font-size: 12px; }
+
+  /* Container */
+  .container { max-width: 1100px; margin: 0 auto; padding: 24px; }
+
+  /* Section */
+  .section { margin-bottom: 24px; }
+  .section-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 0; cursor: pointer; user-select: none; }
+  .section-header h2 { font-size: 15px; font-weight: 600; display: flex; align-items: center; gap: 8px; }
+  .section-header .chevron { transition: transform 0.2s; font-size: 12px; color: var(--text2); }
+  .section-header.open .chevron { transform: rotate(90deg); }
+  .section-body { display: none; }
+  .section-body.open { display: block; }
+
+  /* Task Cards */
+  .task-card { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; margin-bottom: 8px; display: flex; gap: 12px; align-items: flex-start; transition: border-color 0.15s, box-shadow 0.15s; }
+  .task-card.dragging { opacity: 0.5; border-color: var(--accent); }
+  .task-card.drag-over { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+  .task-card.running { border-left: 3px solid var(--orange); }
+  .task-card.completed { border-left: 3px solid var(--green); opacity: 0.7; }
+  .task-card.failed { border-left: 3px solid var(--red); opacity: 0.7; }
+  .drag-handle { cursor: grab; color: var(--text3); padding: 4px; font-size: 16px; line-height: 1; user-select: none; }
+  .drag-handle:active { cursor: grabbing; }
+  .task-content { flex: 1; min-width: 0; }
+  .task-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px; }
+  .task-title { font-weight: 600; font-size: 14px; }
+  .task-meta { display: flex; align-items: center; gap: 12px; font-size: 12px; color: var(--text2); margin-bottom: 6px; flex-wrap: wrap; }
+  .task-prompt { font-size: 13px; color: var(--text2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-bottom: 8px; }
+  .task-controls { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+  .task-controls select { background: var(--bg3); border: 1px solid var(--border); color: var(--text); padding: 3px 8px; border-radius: 4px; font-size: 12px; }
+  .approve-btn { display: inline-flex; align-items: center; gap: 4px; padding: 3px 10px; border-radius: 4px; border: 1px solid; font-size: 12px; cursor: pointer; font-weight: 500; transition: all 0.15s; }
+  .approve-btn.approved { background: #1a3a2a; border-color: var(--green); color: var(--green); }
+  .approve-btn.unapproved { background: var(--bg3); border-color: var(--border); color: var(--text2); }
+
+  /* Slider */
+  .slider-group { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+  .slider-group input[type=range] { width: 100px; accent-color: var(--accent); }
+  .slider-label { color: var(--text2); min-width: 60px; }
+
+  /* Stats badge */
+  .stats-row { display: flex; gap: 12px; font-size: 11px; color: var(--text3); margin-top: 6px; flex-wrap: wrap; }
+  .stats-row span { display: inline-flex; align-items: center; gap: 3px; }
+
+  /* Add Task Form */
+  .add-form { background: var(--bg2); border: 1px dashed var(--border); border-radius: var(--radius); padding: 16px; margin-top: 8px; display: none; }
+  .add-form.open { display: block; }
+  .add-form input, .add-form textarea { width: 100%; background: var(--bg); border: 1px solid var(--border); color: var(--text); padding: 8px 10px; border-radius: 4px; font-size: 13px; font-family: inherit; margin-bottom: 8px; }
+  .add-form textarea { min-height: 80px; resize: vertical; }
+  .form-row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+  .form-row label { font-size: 12px; color: var(--text2); min-width: 80px; }
+
+  /* Permission Profiles */
+  .profile-tabs { display: flex; gap: 4px; margin-bottom: 12px; flex-wrap: wrap; }
+  .profile-tab { padding: 6px 14px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg3); color: var(--text2); cursor: pointer; font-size: 13px; transition: all 0.15s; }
+  .profile-tab.active { background: var(--accent); border-color: var(--accent); color: #000; }
+  .profile-editor { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; }
+  .profile-editor .form-row input, .profile-editor .form-row select { background: var(--bg); border: 1px solid var(--border); color: var(--text); padding: 6px 10px; border-radius: 4px; font-size: 13px; flex: 1; }
+  .profile-editor .form-row input[type=checkbox] { width: auto; flex: none; }
+  .profile-card { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 16px; margin-bottom: 8px; cursor: pointer; transition: border-color 0.15s; }
+  .profile-card:hover { border-color: var(--accent); }
+  .profile-card.selected { border-color: var(--accent); border-width: 2px; }
+  .profile-card-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+  .profile-card-name { font-size: 14px; font-weight: 600; display: flex; align-items: center; gap: 8px; }
+  .profile-card-name .default-badge { font-size: 10px; padding: 1px 6px; border-radius: 3px; background: rgba(88,166,255,0.15); color: var(--accent); font-weight: 500; }
+  .profile-card-desc { font-size: 12px; color: var(--text2); margin-top: 4px; }
+  .profile-card-meta { display: flex; gap: 12px; font-size: 11px; color: var(--text3); margin-top: 6px; }
+  .tool-tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+  .tool-tag { display: inline-flex; align-items: center; gap: 3px; padding: 2px 8px; border-radius: 4px; font-size: 11px; cursor: pointer; transition: all 0.15s; user-select: none; }
+  .tool-tag.allowed { background: rgba(63,185,80,0.12); color: var(--green); border: 1px solid rgba(63,185,80,0.2); }
+  .tool-tag.disallowed { background: rgba(248,81,73,0.12); color: var(--red); border: 1px solid rgba(248,81,73,0.2); }
+  .tool-tag.available { background: var(--bg3); color: var(--text3); border: 1px solid var(--border); }
+  .tool-tag:hover { opacity: 0.8; }
+
+  /* Usage Monitor */
+  .usage-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 700px) { .usage-grid { grid-template-columns: 1fr; } }
+  .usage-card { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px; }
+  .usage-card h3 { font-size: 13px; font-weight: 500; color: var(--text2); margin-bottom: 8px; display: flex; justify-content: space-between; }
+  .usage-bar { height: 6px; background: var(--bg4); border-radius: 3px; overflow: hidden; margin-bottom: 4px; }
+  .usage-bar-fill { height: 100%; border-radius: 3px; transition: width 0.5s; }
+  .usage-bar-fill.green { background: var(--green); }
+  .usage-bar-fill.orange { background: var(--orange); }
+  .usage-bar-fill.red { background: var(--red); }
+  .usage-bar-fill.blue { background: var(--accent); }
+  .usage-bar-fill.purple { background: var(--purple); }
+  .usage-percent { font-size: 20px; font-weight: 600; }
+  .usage-detail { font-size: 12px; color: var(--text2); }
+  .usage-chart { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px; margin-top: 16px; }
+  .usage-chart svg { width: 100%; height: 120px; }
+
+  /* Setup form */
+  .setup-row { display: flex; align-items: center; gap: 8px; margin-top: 12px; font-size: 12px; }
+  .setup-row input { background: var(--bg); border: 1px solid var(--border); color: var(--text); padding: 4px 8px; border-radius: 4px; font-size: 12px; flex: 1; max-width: 300px; }
+
+  /* Log */
+  .log-output { background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 11px; max-height: 300px; overflow-y: auto; white-space: pre-wrap; color: var(--text2); line-height: 1.6; }
+
+  /* Summary */
+  .summary-content { background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; font-size: 13px; max-height: 400px; overflow-y: auto; white-space: pre-wrap; }
+
+  /* Delete btn on card */
+  .task-delete { color: var(--text3); cursor: pointer; padding: 4px; font-size: 14px; transition: color 0.15s; }
+  .task-delete:hover { color: var(--red); }
+
+  /* Task enhancements */
+  .task-badge { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; }
+  .task-badge.project { background: rgba(88,166,255,0.12); color: var(--accent); }
+  .task-badge.queue { background: var(--bg4); color: var(--text2); }
+  .task-badge.waiting { background: rgba(210,153,34,0.12); color: var(--orange); }
+  .task-session { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text3); margin-top: 4px; }
+  .task-session code { background: var(--bg4); padding: 1px 6px; border-radius: 3px; font-family: 'SF Mono', Monaco, monospace; cursor: pointer; transition: background 0.15s; }
+  .task-session code:hover { background: var(--accent); color: #000; }
+
+  /* Project Cards */
+  .project-card { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; margin-bottom: 12px; }
+  .project-card.active { border-left: 3px solid var(--green); }
+  .project-card.idle { border-left: 3px solid var(--orange); }
+  .project-card.complete { border-left: 3px solid var(--accent); }
+  .project-card.empty { border-left: 3px solid var(--text3); }
+  .project-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
+  .project-name { font-size: 15px; font-weight: 600; display: flex; align-items: center; gap: 8px; }
+  .project-name .activity-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  .project-desc { font-size: 13px; color: var(--text2); margin-bottom: 10px; }
+  .project-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; }
+  .project-meta-tag { display: inline-flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: 4px; font-size: 11px; background: var(--bg3); color: var(--text2); }
+  .project-meta-tag.dir { color: var(--accent); background: rgba(88,166,255,0.08); }
+  .project-meta-tag.ssh { color: var(--purple); background: rgba(188,140,255,0.08); }
+  .project-meta-tag.md { color: var(--orange); background: rgba(210,153,34,0.08); }
+  .project-meta-tag.repo { color: var(--green); background: rgba(63,185,80,0.08); }
+  .project-tasks { border-top: 1px solid var(--border); padding-top: 10px; }
+  .project-tasks h4 { font-size: 12px; font-weight: 500; color: var(--text2); margin-bottom: 6px; }
+  .project-task-row { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 12px; }
+  .project-task-row .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .project-task-row .dot.pending { background: var(--text3); }
+  .project-task-row .dot.running { background: var(--orange); }
+  .project-task-row .dot.completed { background: var(--green); }
+  .project-task-row .dot.failed { background: var(--red); }
+  .project-actions { display: flex; gap: 6px; align-items: center; }
+  .project-actions .btn-sm { padding: 2px 8px; font-size: 11px; }
+  .add-project-form { background: var(--bg2); border: 1px dashed var(--border); border-radius: var(--radius); padding: 16px; margin-top: 8px; display: none; }
+  .add-project-form.open { display: block; }
+  .add-project-form input, .add-project-form textarea { width: 100%; background: var(--bg); border: 1px solid var(--border); color: var(--text); padding: 8px 10px; border-radius: 4px; font-size: 13px; font-family: inherit; margin-bottom: 8px; }
+  .add-project-form textarea { min-height: 60px; resize: vertical; }
+  .unassigned-section { margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--border); }
+  .unassigned-section h3 { font-size: 14px; font-weight: 600; color: var(--text2); margin-bottom: 8px; }
+
+  /* Location Cards */
+  .loc-group { margin-bottom: 20px; }
+  .loc-group h3 { font-size: 13px; font-weight: 600; color: var(--text2); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+  .loc-group h3 .count { font-weight: 400; color: var(--text3); }
+  .loc-card { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; margin-bottom: 6px; display: flex; align-items: center; gap: 12px; }
+  .loc-card.running { border-left: 3px solid var(--green); }
+  .loc-card.idle { border-left: 3px solid var(--text3); }
+  .loc-card.archived { border-left: 3px solid var(--text3); opacity: 0.5; }
+  .loc-status { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  .loc-status.running { background: var(--green); box-shadow: 0 0 6px var(--green); }
+  .loc-status.idle { background: var(--text3); }
+  .loc-status.archived { background: var(--text3); }
+  .loc-info { flex: 1; min-width: 0; }
+  .loc-title { font-size: 13px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .loc-detail { display: flex; gap: 12px; font-size: 11px; color: var(--text2); margin-top: 2px; flex-wrap: wrap; }
+  .loc-detail span { display: inline-flex; align-items: center; gap: 3px; }
+  .loc-tags { display: flex; gap: 6px; flex-shrink: 0; flex-wrap: wrap; }
+  .loc-tag { padding: 2px 8px; border-radius: 4px; font-size: 10px; font-weight: 500; }
+  .loc-tag.model { background: rgba(88,166,255,0.1); color: var(--accent); }
+  .loc-tag.perm { background: rgba(63,185,80,0.1); color: var(--green); }
+  .loc-tag.status-running { background: rgba(63,185,80,0.15); color: var(--green); }
+  .loc-tag.status-idle { background: var(--bg4); color: var(--text3); }
+
+  /* Tab Navigation */
+  .tab-bar { display: flex; background: var(--bg2); border-bottom: 1px solid var(--border); padding: 0 24px; gap: 0; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .tab-btn { padding: 10px 20px; font-size: 13px; font-weight: 500; color: var(--text2); background: none; border: none; border-bottom: 2px solid transparent; cursor: pointer; transition: all 0.15s; white-space: nowrap; font-family: inherit; }
+  .tab-btn:hover { color: var(--text); background: var(--bg3); }
+  .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .tab-btn .tab-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 18px; height: 18px; padding: 0 5px; border-radius: 9px; background: var(--bg4); font-size: 11px; margin-left: 6px; color: var(--text2); }
+  .tab-btn.active .tab-badge { background: rgba(88,166,255,0.15); color: var(--accent); }
+  .tab-panel { display: none; }
+  .tab-panel.active { display: block; }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="header-left">
+    <h1>AutoClaude</h1>
+    <span id="statusBadge" class="status-badge status-WORK"><span class="dot"></span><span id="statusText">WORK</span></span>
+    <span id="creditStatus" style="font-size:12px;color:var(--text2)"></span>
+  </div>
+  <div class="header-controls">
+    <div class="time-input"><span>Bed</span><input type="text" id="bedTime" value="23:00" maxlength="5" placeholder="HH:MM" onfocus="this.select()" onblur="validateTime(this)"></div>
+    <div class="time-input"><span>Wake</span><input type="text" id="wakeTime" value="07:00" maxlength="5" placeholder="HH:MM" onfocus="this.select()" onblur="validateTime(this)"></div>
+    <div class="time-input"><span>Work</span><input type="text" id="workTime" value="09:00" maxlength="5" placeholder="HH:MM" onfocus="this.select()" onblur="validateTime(this)"></div>
+    <button id="startStopBtn" class="btn btn-primary" onclick="toggleDaemon()">Start</button>
+  </div>
+</div>
+
+<div class="tab-bar">
+  <button class="tab-btn active" data-tab="tasks" onclick="switchTab('tasks')">Tasks<span id="taskBadge" class="tab-badge">0</span></button>
+  <button class="tab-btn" data-tab="projects" onclick="switchTab('projects')">Projects<span id="projectBadge" class="tab-badge">0</span></button>
+  <button class="tab-btn" data-tab="locations" onclick="switchTab('locations')">Locations<span id="locationBadge" class="tab-badge">0</span></button>
+  <button class="tab-btn" data-tab="usage" onclick="switchTab('usage')">Usage</button>
+  <button class="tab-btn" data-tab="permissions" onclick="switchTab('permissions')">Permissions</button>
+</div>
+
+<div class="container">
+  <!-- Tasks Tab -->
+  <div id="tab-tasks" class="tab-panel active">
+    <div class="section">
+      <div class="section-header open" onclick="toggleSection(this)">
+        <h2><span class="chevron">&#9654;</span> Task Queue <span id="taskCount" style="color:var(--text2);font-weight:400"></span></h2>
+        <button class="btn btn-sm" onclick="event.stopPropagation();toggleAddForm()">+ Add Task</button>
+      </div>
+      <div class="section-body open">
+        <div id="taskList"></div>
+        <div id="addForm" class="add-form">
+          <input id="newTitle" placeholder="Task title" />
+          <textarea id="newPrompt" placeholder="Detailed prompt / instructions for Claude..."></textarea>
+          <div class="form-row">
+            <label>Directory</label>
+            <input id="newDir" placeholder="/path/to/project" />
+          </div>
+          <div class="form-row">
+            <label>Project</label>
+            <select id="newProject"><option value="">— None —</option></select>
+          </div>
+          <div class="form-row">
+            <label>Profile</label>
+            <select id="newProfile"></select>
+          </div>
+          <div class="form-row">
+            <label>Sub-agents</label>
+            <div class="slider-group">
+              <input type="range" id="newSubagent" min="0" max="1" step="0.05" value="0.5" oninput="document.getElementById('newSubagentLabel').textContent=subagentLabel(this.value)">
+              <span id="newSubagentLabel" class="slider-label">Moderate</span>
+            </div>
+          </div>
+          <div style="display:flex;gap:8px;justify-content:flex-end">
+            <button class="btn" onclick="toggleAddForm()">Cancel</button>
+            <button class="btn btn-primary" onclick="addTask()">Add Task</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Activity Log (inside Tasks tab) -->
+    <div class="section">
+      <div class="section-header" onclick="toggleSection(this)">
+        <h2><span class="chevron">&#9654;</span> Activity Log</h2>
+      </div>
+      <div class="section-body">
+        <div id="logOutput" class="log-output">Loading...</div>
+      </div>
+    </div>
+
+    <!-- Overnight Summary (inside Tasks tab) -->
+    <div class="section">
+      <div class="section-header" onclick="toggleSection(this)">
+        <h2><span class="chevron">&#9654;</span> Overnight Summary</h2>
+      </div>
+      <div class="section-body">
+        <div id="summaryContent" class="summary-content">No summary available yet.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Projects Tab -->
+  <div id="tab-projects" class="tab-panel">
+    <div class="section">
+      <div class="section-header open">
+        <h2>Projects</h2>
+        <button class="btn btn-sm" onclick="toggleProjectForm()">+ New Project</button>
+      </div>
+      <div class="section-body open">
+        <div id="addProjectForm" class="add-project-form">
+          <input id="projName" placeholder="Project name" />
+          <textarea id="projDesc" placeholder="Description (optional)"></textarea>
+          <div class="form-row">
+            <label>Main Dir</label>
+            <input id="projDir" placeholder="/path/to/project" />
+          </div>
+          <div class="form-row">
+            <label>SSH Locs</label>
+            <input id="projSsh" placeholder="user@host:/path, ... (comma-separated)" />
+          </div>
+          <div class="form-row">
+            <label>CLAUDE.md</label>
+            <input id="projMd" placeholder="/path/to/CLAUDE.md, ... (comma-separated)" />
+          </div>
+          <div class="form-row">
+            <label>GitHub</label>
+            <input id="projRepos" placeholder="owner/repo, ... (comma-separated)" />
+          </div>
+          <input type="hidden" id="projEditId" value="" />
+          <div style="display:flex;gap:8px;justify-content:flex-end">
+            <button class="btn" onclick="toggleProjectForm()">Cancel</button>
+            <button class="btn btn-primary" onclick="saveProject()">Save Project</button>
+          </div>
+        </div>
+        <div id="projectCards"></div>
+        <div id="unassignedTasks" class="unassigned-section" style="display:none"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Locations Tab -->
+  <div id="tab-locations" class="tab-panel">
+    <div class="section">
+      <div class="section-header open">
+        <h2>Claude Locations <span id="locCount" style="color:var(--text2);font-weight:400;font-size:13px"></span></h2>
+        <button class="btn btn-sm" onclick="loadSessions()">Refresh</button>
+      </div>
+      <div class="section-body open">
+        <div id="locationsList"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Usage Tab -->
+  <div id="tab-usage" class="tab-panel">
+    <!-- Connection Status -->
+    <div class="section">
+      <div class="section-header open">
+        <h2>Connection Status</h2>
+      </div>
+      <div class="section-body open">
+        <div id="connectionStatus" style="display:flex;align-items:center;gap:8px;margin-bottom:12px;font-size:13px">
+          <span id="connDot" style="width:8px;height:8px;border-radius:50%;background:var(--text3)"></span>
+          <span id="connText" style="color:var(--text2)">Not connected</span>
+        </div>
+        <div class="setup-row" style="margin-top:0">
+          <span style="color:var(--text2)">Session Cookie:</span>
+          <input type="password" id="sessionKeyInput" placeholder="Paste sessionKey cookie value" />
+          <input id="orgIdInput" placeholder="Org ID" style="max-width:200px" />
+          <button class="btn btn-sm" onclick="saveApiConfig()">Save</button>
+          <button class="btn btn-sm" onclick="refreshUsage()">Refresh</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Usage Meters -->
+    <div class="section">
+      <div class="section-header open">
+        <h2>Plan Usage</h2>
+      </div>
+      <div class="section-body open">
+        <div id="usageGrid" class="usage-grid"></div>
+        <div id="usageChart" class="usage-chart" style="display:none"></div>
+      </div>
+    </div>
+
+    <!-- Overnight Management -->
+    <div class="section">
+      <div class="section-header open" onclick="toggleSection(this)">
+        <h2><span class="chevron">&#9654;</span> Overnight Management</h2>
+      </div>
+      <div class="section-body open">
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+          <div class="usage-card">
+            <h3>Schedule</h3>
+            <div style="display:flex;gap:16px;margin-top:8px">
+              <div class="time-input"><span>Bed</span><input type="text" id="usageBedTime" value="23:00" maxlength="5" placeholder="HH:MM" onfocus="this.select()" onblur="validateTime(this)"></div>
+              <div class="time-input"><span>Wake</span><input type="text" id="usageWakeTime" value="07:00" maxlength="5" placeholder="HH:MM" onfocus="this.select()" onblur="validateTime(this)"></div>
+              <div class="time-input"><span>Work</span><input type="text" id="usageWorkTime" value="09:00" maxlength="5" placeholder="HH:MM" onfocus="this.select()" onblur="validateTime(this)"></div>
+            </div>
+            <button class="btn btn-sm" style="margin-top:8px" onclick="saveScheduleFromUsage()">Update Schedule</button>
+          </div>
+          <div class="usage-card">
+            <h3>Credit Resets</h3>
+            <div id="resetTimers" style="font-size:13px;color:var(--text2);margin-top:8px">
+              <p>No reset data available</p>
+            </div>
+          </div>
+        </div>
+        <div class="usage-card" style="margin-top:16px">
+          <h3>Overnight Queue</h3>
+          <div id="overnightQueue" style="font-size:13px;color:var(--text2);margin-top:8px">
+            <p>No approved tasks in queue</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Permissions Tab -->
+  <div id="tab-permissions" class="tab-panel">
+    <div class="section">
+      <div class="section-header open">
+        <h2>Permission Profiles</h2>
+        <div style="display:flex;gap:6px">
+          <button class="btn btn-sm" onclick="createNewProfile()">+ New Profile</button>
+          <button class="btn btn-sm" onclick="exportProfiles()">Export</button>
+          <button class="btn btn-sm" onclick="document.getElementById('importInput').click()">Import</button>
+          <input type="file" id="importInput" accept=".json" style="display:none" onchange="importProfiles(this)" />
+        </div>
+      </div>
+      <div class="section-body open">
+        <div id="profileCards"></div>
+        <div id="profileEditor" class="profile-editor" style="display:none"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+const API = '';
+let tasks = [];
+let profiles = {};
+let projects = [];
+let activeProfileKey = null;
+let dragSrcId = null;
+
+// ─── Tab Navigation ───
+function switchTab(tabId) {
+  document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  const panel = document.getElementById('tab-' + tabId);
+  const btn = document.querySelector('.tab-btn[data-tab="' + tabId + '"]');
+  if (panel) panel.classList.add('active');
+  if (btn) btn.classList.add('active');
+  history.replaceState(null, '', '#' + tabId);
+}
+
+function initTabFromHash() {
+  const hash = location.hash.replace('#', '');
+  const validTabs = ['tasks', 'projects', 'locations', 'usage', 'permissions'];
+  if (hash && validTabs.includes(hash)) {
+    switchTab(hash);
+  }
+}
+
+function updateTabBadges() {
+  const taskBadge = document.getElementById('taskBadge');
+  if (taskBadge) taskBadge.textContent = tasks.length;
+  const projBadge = document.getElementById('projectBadge');
+  if (projBadge) projBadge.textContent = projects.length;
+}
+
+// ─── Time Input ───
+function validateTime(input) {
+  let val = input.value.replace(/[^0-9:]/g, '');
+  // Auto-format: "7" → "07:00", "23" → "23:00", "730" → "07:30"
+  if (/^\\d{1,2}$/.test(val)) {
+    val = val.padStart(2, '0') + ':00';
+  } else if (/^\\d{3}$/.test(val)) {
+    val = '0' + val[0] + ':' + val.slice(1);
+  } else if (/^\\d{4}$/.test(val)) {
+    val = val.slice(0, 2) + ':' + val.slice(2);
+  }
+  const match = val.match(/^(\\d{1,2}):(\\d{2})$/);
+  if (match) {
+    let h = parseInt(match[1]), m = parseInt(match[2]);
+    h = Math.min(23, Math.max(0, h));
+    m = Math.min(59, Math.max(0, m));
+    input.value = String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0');
+    input.style.borderColor = '';
+  } else {
+    input.style.borderColor = 'var(--red)';
+  }
+}
+
+// ─── Helpers ───
+function subagentLabel(v) {
+  v = parseFloat(v);
+  if (v <= 0.05) return 'None';
+  if (v <= 0.3) return 'Minimal';
+  if (v <= 0.6) return 'Moderate';
+  if (v <= 0.85) return 'Heavy';
+  return 'Maximum';
+}
+
+function usageColor(pct) {
+  if (pct >= 90) return 'red';
+  if (pct >= 60) return 'orange';
+  return 'green';
+}
+
+async function api(path, opts = {}) {
+  const res = await fetch(API + path, {
+    headers: { 'Content-Type': 'application/json' },
+    ...opts,
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  return res.json();
+}
+
+// ─── Sections ───
+function toggleSection(el) {
+  el.classList.toggle('open');
+  const body = el.nextElementSibling;
+  body.classList.toggle('open');
+}
+
+// ─── Tasks ───
+async function loadTaskList() {
+  tasks = await api('/api/tasks');
+  tasks.sort((a, b) => (a.order || 0) - (b.order || 0));
+  renderTasks();
+}
+
+function renderTasks() {
+  const list = document.getElementById('taskList');
+  const count = document.getElementById('taskCount');
+  const pending = tasks.filter(t => t.status === 'pending').length;
+  const approved = tasks.filter(t => t.approved && t.status === 'pending').length;
+  count.textContent = '(' + approved + ' approved / ' + tasks.length + ' total)';
+  updateTabBadges();
+
+  const pendingTasks = tasks.filter(t => t.status === 'pending');
+  list.innerHTML = tasks.map((t, idx) => {
+    const statusClass = t.status === 'running' ? 'running' : t.status === 'completed' ? 'completed' : t.status === 'failed' ? 'failed' : '';
+    const approveClass = t.approved ? 'approved' : 'unapproved';
+    const approveText = t.approved ? '\\u2713 Approved' : '\\u2717 Unapproved';
+
+    // Queue position for pending tasks
+    const queuePos = t.status === 'pending' ? pendingTasks.indexOf(t) + 1 : 0;
+    const queueHtml = queuePos > 0 ? '<span class="task-badge queue">#' + queuePos + ' of ' + pendingTasks.length + '</span>' : '';
+
+    // Project badge
+    const proj = t.project ? projects.find(p => p.id === t.project) : null;
+    const projectHtml = proj ? '<span class="task-badge project">' + esc(proj.name) + '</span>' : '';
+
+    // Dependency indicator
+    const deps = t.dependencies?.length ? t.dependencies.map(depId => {
+      const dep = tasks.find(x => x.id === depId);
+      return dep ? dep.title : 'Unknown';
+    }) : [];
+    const waitingDeps = t.dependencies?.length ? t.dependencies.filter(depId => {
+      const dep = tasks.find(x => x.id === depId);
+      return dep && dep.status !== 'completed';
+    }) : [];
+    const depsHtml = waitingDeps.length > 0 ? '<span class="task-badge waiting">Waiting on ' + waitingDeps.length + ' task' + (waitingDeps.length > 1 ? 's' : '') + '</span>' : '';
+
+    // Session info
+    let sessionHtml = '';
+    if (t.sessionId) {
+      sessionHtml = '<div class="task-session">' +
+        '<span>Session:</span>' +
+        '<code onclick="copyResume(\\'' + t.sessionId + '\\')" title="Click to copy resume command">' + t.sessionId.slice(0, 8) + '...</code>' +
+      '</div>';
+    }
+
+    let statsHtml = '';
+    if (t.stats) {
+      statsHtml = '<div class="stats-row">' +
+        '<span>Claude: ' + (t.stats.claudeDirectWork || 0) + ' tool uses</span>' +
+        '<span>Sub-agents: ' + (t.stats.subagentCount || 0) + ' (' + Math.round((t.stats.subagentRatio || 0) * 100) + '%)</span>' +
+        (t.stats.models?.length ? '<span>Models: ' + t.stats.models.join(', ') + '</span>' : '') +
+        '</div>';
+      if (t.stats.subagentCalls?.length) {
+        statsHtml += '<div class="stats-row" style="flex-direction:column;gap:2px;margin-top:4px">' +
+          t.stats.subagentCalls.map(s => '<span style="color:var(--purple)">[' + s.subagentType + '] ' + s.description + ' (' + s.model + ')</span>').join('') +
+          '</div>';
+      }
+    }
+
+    return '<div class="task-card ' + statusClass + '" draggable="true" data-id="' + t.id + '" ' +
+      'ondragstart="onDragStart(event)" ondragover="onDragOver(event)" ondrop="onDrop(event)" ondragend="onDragEnd(event)" ondragleave="onDragLeave(event)">' +
+      '<div class="drag-handle">\\u2630</div>' +
+      '<div class="task-content">' +
+        '<div class="task-top">' +
+          '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
+            '<span class="task-title">' + esc(t.title) + '</span>' +
+            queueHtml + projectHtml + depsHtml +
+          '</div>' +
+          '<div style="display:flex;gap:6px;align-items:center">' +
+            '<span class="approve-btn ' + approveClass + '" onclick="toggleApprove(\\'' + t.id + '\\')">' + approveText + '</span>' +
+            '<span class="task-delete" onclick="removeTask(\\'' + t.id + '\\')" title="Delete">&times;</span>' +
+          '</div>' +
+        '</div>' +
+        '<div class="task-meta">' +
+          '<span>' + esc(t.dir) + '</span>' +
+          (t.status !== 'pending' ? '<span style="text-transform:uppercase;color:' + (t.status === 'completed' ? 'var(--green)' : t.status === 'failed' ? 'var(--red)' : 'var(--orange)') + '">' + t.status + '</span>' : '') +
+        '</div>' +
+        '<div class="task-prompt">' + esc(t.prompt || '') + '</div>' +
+        '<div class="task-controls">' +
+          '<select onchange="updateTaskField(\\'' + t.id + '\\', \\'project\\', this.value||null)">' +
+            '<option value="">— No Project —</option>' +
+            projects.map(p => '<option value="' + p.id + '"' + (p.id === t.project ? ' selected' : '') + '>' + esc(p.name) + '</option>').join('') +
+          '</select>' +
+          '<select onchange="updateTaskField(\\'' + t.id + '\\', \\'permissionProfile\\', this.value)">' +
+            Object.keys(profiles).map(k => '<option value="' + k + '"' + (k === t.permissionProfile ? ' selected' : '') + '>' + esc(profiles[k]?.name || k) + '</option>').join('') +
+          '</select>' +
+          '<div class="slider-group">' +
+            '<span style="color:var(--text2)">Sub-agents:</span>' +
+            '<input type="range" min="0" max="1" step="0.05" value="' + (t.subagentLevel ?? 0.5) + '" ' +
+              'oninput="this.nextElementSibling.textContent=subagentLabel(this.value)" ' +
+              'onchange="updateTaskField(\\'' + t.id + '\\', \\'subagentLevel\\', parseFloat(this.value))">' +
+            '<span class="slider-label">' + subagentLabel(t.subagentLevel ?? 0.5) + '</span>' +
+          '</div>' +
+        '</div>' +
+        sessionHtml +
+        statsHtml +
+      '</div>' +
+    '</div>';
+  }).join('');
+}
+
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+function copyResume(sessionId) {
+  navigator.clipboard.writeText('claude --resume ' + sessionId);
+  const el = event.target;
+  const orig = el.textContent;
+  el.textContent = 'Copied!';
+  setTimeout(() => { el.textContent = orig; }, 1500);
+}
+
+async function toggleApprove(id) {
+  const t = tasks.find(x => x.id === id);
+  if (!t) return;
+  await api('/api/tasks/' + id, { method: 'PUT', body: { approved: !t.approved } });
+  loadTaskList();
+}
+
+async function updateTaskField(id, field, value) {
+  await api('/api/tasks/' + id, { method: 'PUT', body: { [field]: value } });
+  loadTaskList();
+}
+
+async function removeTask(id) {
+  if (!confirm('Delete this task?')) return;
+  await api('/api/tasks/' + id, { method: 'DELETE' });
+  loadTaskList();
+}
+
+function toggleAddForm() {
+  document.getElementById('addForm').classList.toggle('open');
+}
+
+async function addTask() {
+  const title = document.getElementById('newTitle').value.trim();
+  const prompt = document.getElementById('newPrompt').value.trim();
+  const dir = document.getElementById('newDir').value.trim();
+  const project = document.getElementById('newProject').value || null;
+  const profile = document.getElementById('newProfile').value;
+  const subagentLevel = parseFloat(document.getElementById('newSubagent').value);
+  if (!title) return alert('Title required');
+  if (!prompt) return alert('Prompt required');
+  await api('/api/tasks', { method: 'POST', body: { title, prompt, dir, project, permissionProfile: profile, subagentLevel } });
+  document.getElementById('newTitle').value = '';
+  document.getElementById('newPrompt').value = '';
+  document.getElementById('newDir').value = '';
+  toggleAddForm();
+  loadTaskList();
+}
+
+// ─── Drag & Drop ───
+function onDragStart(e) {
+  dragSrcId = e.currentTarget.dataset.id;
+  e.currentTarget.classList.add('dragging');
+  e.dataTransfer.effectAllowed = 'move';
+}
+function onDragOver(e) {
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
+  e.currentTarget.classList.add('drag-over');
+}
+function onDragLeave(e) { e.currentTarget.classList.remove('drag-over'); }
+function onDragEnd(e) {
+  e.currentTarget.classList.remove('dragging');
+  document.querySelectorAll('.task-card').forEach(c => c.classList.remove('drag-over'));
+}
+async function onDrop(e) {
+  e.preventDefault();
+  e.currentTarget.classList.remove('drag-over');
+  const targetId = e.currentTarget.dataset.id;
+  if (dragSrcId === targetId) return;
+  const ids = tasks.map(t => t.id);
+  const srcIdx = ids.indexOf(dragSrcId);
+  const tgtIdx = ids.indexOf(targetId);
+  ids.splice(srcIdx, 1);
+  ids.splice(tgtIdx, 0, dragSrcId);
+  await api('/api/tasks/reorder', { method: 'PUT', body: { orderedIds: ids } });
+  loadTaskList();
+}
+
+// ─── Profiles ───
+async function loadProfiles() {
+  const data = await api('/api/permissions');
+  profiles = data.profiles || {};
+  renderProfileCards();
+  populateProfileDropdowns();
+}
+
+const KNOWN_TOOLS = ['Read', 'Edit', 'Write', 'Glob', 'Grep', 'Bash', 'WebFetch', 'WebSearch', 'Task', 'NotebookEdit'];
+
+function renderProfileCards() {
+  const container = document.getElementById('profileCards');
+  if (!container) return;
+  const keys = Object.keys(profiles);
+  const config = window._cachedConfig || {};
+  const defaultProfile = config.defaultPermissionProfile || 'full-auto';
+
+  container.innerHTML = keys.map(k => {
+    const p = profiles[k];
+    const usageCount = tasks.filter(t => t.permissionProfile === k).length;
+    const isDefault = k === defaultProfile;
+    const isSelected = k === activeProfileKey;
+
+    return '<div class="profile-card' + (isSelected ? ' selected' : '') + '" onclick="selectProfile(\\'' + k + '\\')">' +
+      '<div class="profile-card-header">' +
+        '<div class="profile-card-name">' + esc(p.name || k) +
+          (isDefault ? ' <span class="default-badge">Default</span>' : '') +
+        '</div>' +
+        '<div style="display:flex;gap:6px;align-items:center">' +
+          '<span style="font-size:11px;color:var(--text3)">' + usageCount + ' task' + (usageCount !== 1 ? 's' : '') + '</span>' +
+          '<button class="btn btn-sm" onclick="event.stopPropagation();duplicateProfile(\\'' + k + '\\')" title="Duplicate">\\ud83d\\udccb</button>' +
+          (!isDefault ? '<button class="btn btn-sm" onclick="event.stopPropagation();setDefaultProfile(\\'' + k + '\\')" title="Set as default">\\u2b50</button>' : '') +
+        '</div>' +
+      '</div>' +
+      '<div class="profile-card-desc">' + esc(p.description || '') + '</div>' +
+      '<div class="profile-card-meta">' +
+        '<span>Mode: ' + esc(p.permissionMode || 'default') + '</span>' +
+        (p.dangerouslySkipPermissions ? '<span style="color:var(--orange)">Skip permissions</span>' : '') +
+        (p.allowedTools?.length ? '<span style="color:var(--green)">' + p.allowedTools.length + ' allowed</span>' : '') +
+        (p.disallowedTools?.length ? '<span style="color:var(--red)">' + p.disallowedTools.length + ' blocked</span>' : '') +
+      '</div>' +
+    '</div>';
+  }).join('');
+}
+
+function selectProfile(key) {
+  activeProfileKey = key;
+  renderProfileCards();
+  renderProfileEditor();
+}
+
+function renderProfileEditor() {
+  const editor = document.getElementById('profileEditor');
+  if (!activeProfileKey || !profiles[activeProfileKey]) { editor.style.display = 'none'; return; }
+  editor.style.display = 'block';
+  const p = profiles[activeProfileKey];
+  const modes = ['default','acceptEdits','bypassPermissions','dontAsk','plan'];
+
+  // Build tool tags
+  const allowed = new Set(p.allowedTools || []);
+  const disallowed = new Set(p.disallowedTools || []);
+  const allTools = [...new Set([...KNOWN_TOOLS, ...allowed, ...disallowed])];
+
+  const toolTagsHtml = '<div style="margin-top:4px"><label style="font-size:12px;color:var(--text2);display:block;margin-bottom:4px">Tools <span style="color:var(--text3)">(click to toggle: green=allowed, red=blocked, gray=unset)</span></label>' +
+    '<div class="tool-tags">' +
+    allTools.map(t => {
+      const cls = allowed.has(t) ? 'allowed' : disallowed.has(t) ? 'disallowed' : 'available';
+      return '<span class="tool-tag ' + cls + '" onclick="toggleTool(\\'' + esc(t) + '\\')">' + esc(t) + '</span>';
+    }).join('') +
+    '</div></div>';
+
+  editor.innerHTML =
+    '<div class="form-row"><label>Key</label><input value="' + esc(activeProfileKey) + '" disabled /></div>' +
+    '<div class="form-row"><label>Name</label><input id="pName" value="' + esc(p.name || '') + '" /></div>' +
+    '<div class="form-row"><label>Description</label><input id="pDesc" value="' + esc(p.description || '') + '" /></div>' +
+    '<div class="form-row"><label>Mode</label><select id="pMode">' + modes.map(m => '<option' + (m === p.permissionMode ? ' selected' : '') + '>' + m + '</option>').join('') + '</select></div>' +
+    '<div class="form-row"><label>Skip Perms</label><input type="checkbox" id="pSkip"' + (p.dangerouslySkipPermissions ? ' checked' : '') + ' /></div>' +
+    toolTagsHtml +
+    '<div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px">' +
+      '<button class="btn btn-danger btn-sm" onclick="deleteProfile()">Delete</button>' +
+      '<button class="btn btn-primary btn-sm" onclick="saveProfile()">Save</button>' +
+    '</div>';
+}
+
+function toggleTool(toolName) {
+  if (!activeProfileKey || !profiles[activeProfileKey]) return;
+  const p = profiles[activeProfileKey];
+  const allowed = new Set(p.allowedTools || []);
+  const disallowed = new Set(p.disallowedTools || []);
+
+  if (allowed.has(toolName)) {
+    // allowed → disallowed
+    allowed.delete(toolName);
+    disallowed.add(toolName);
+  } else if (disallowed.has(toolName)) {
+    // disallowed → unset
+    disallowed.delete(toolName);
+  } else {
+    // unset → allowed
+    allowed.add(toolName);
+  }
+
+  p.allowedTools = [...allowed];
+  p.disallowedTools = [...disallowed];
+  renderProfileEditor();
+}
+
+async function saveProfile() {
+  const profile = {
+    name: document.getElementById('pName').value,
+    description: document.getElementById('pDesc').value,
+    permissionMode: document.getElementById('pMode').value,
+    dangerouslySkipPermissions: document.getElementById('pSkip').checked,
+    allowedTools: profiles[activeProfileKey]?.allowedTools || [],
+    disallowedTools: profiles[activeProfileKey]?.disallowedTools || [],
+  };
+  await api('/api/permissions/' + activeProfileKey, { method: 'PUT', body: profile });
+  loadProfiles();
+}
+
+async function deleteProfile() {
+  if (!confirm('Delete profile "' + activeProfileKey + '"?')) return;
+  await api('/api/permissions/' + activeProfileKey, { method: 'DELETE' });
+  activeProfileKey = null;
+  document.getElementById('profileEditor').style.display = 'none';
+  loadProfiles();
+}
+
+async function createNewProfile() {
+  const key = prompt('Profile key (lowercase, no spaces):');
+  if (!key) return;
+  await api('/api/permissions', { method: 'POST', body: { key, profile: { name: key, description: '', permissionMode: 'default', dangerouslySkipPermissions: false, allowedTools: [], disallowedTools: [] } } });
+  activeProfileKey = key;
+  loadProfiles();
+}
+
+async function duplicateProfile(key) {
+  const p = profiles[key];
+  if (!p) return;
+  const newKey = prompt('New profile key:', key + '-copy');
+  if (!newKey) return;
+  await api('/api/permissions', { method: 'POST', body: { key: newKey, profile: { ...p, name: (p.name || key) + ' (Copy)' } } });
+  activeProfileKey = newKey;
+  loadProfiles();
+}
+
+async function setDefaultProfile(key) {
+  await api('/api/config', { method: 'POST', body: { defaultPermissionProfile: key } });
+  window._cachedConfig = window._cachedConfig || {};
+  window._cachedConfig.defaultPermissionProfile = key;
+  renderProfileCards();
+}
+
+function exportProfiles() {
+  const data = JSON.stringify({ profiles }, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'autoclaude-permissions.json';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function importProfiles(input) {
+  const file = input.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = async (e) => {
+    try {
+      const data = JSON.parse(e.target.result);
+      const imported = data.profiles || {};
+      for (const [key, profile] of Object.entries(imported)) {
+        await api('/api/permissions', { method: 'POST', body: { key, profile } });
+      }
+      loadProfiles();
+      alert('Imported ' + Object.keys(imported).length + ' profile(s)');
+    } catch (err) {
+      alert('Import failed: ' + err.message);
+    }
+  };
+  reader.readAsText(file);
+  input.value = '';
+}
+
+function populateProfileDropdowns() {
+  const selects = [document.getElementById('newProfile')];
+  for (const sel of selects) {
+    if (!sel) continue;
+    sel.innerHTML = Object.keys(profiles).map(k => '<option value="' + k + '">' + esc(profiles[k].name || k) + '</option>').join('');
+  }
+}
+
+// ─── Projects ───
+async function loadProjectsList() {
+  projects = await api('/api/projects');
+  populateProjectDropdowns();
+  renderProjectCards();
+}
+
+function populateProjectDropdowns() {
+  const sel = document.getElementById('newProject');
+  if (!sel) return;
+  sel.innerHTML = '<option value="">\\u2014 None \\u2014</option>' +
+    projects.map(p => '<option value="' + p.id + '">' + esc(p.name) + '</option>').join('');
+}
+
+function toggleProjectForm(editProject) {
+  const form = document.getElementById('addProjectForm');
+  const editId = document.getElementById('projEditId');
+  if (editProject) {
+    document.getElementById('projName').value = editProject.name || '';
+    document.getElementById('projDesc').value = editProject.description || '';
+    document.getElementById('projDir').value = editProject.mainDir || '';
+    document.getElementById('projSsh').value = (editProject.sshLocations || []).join(', ');
+    document.getElementById('projMd').value = (editProject.claudeMdPaths || []).join(', ');
+    document.getElementById('projRepos').value = (editProject.githubRepos || []).join(', ');
+    editId.value = editProject.id;
+    form.classList.add('open');
+  } else if (form.classList.contains('open') && !editId.value) {
+    form.classList.remove('open');
+  } else {
+    document.getElementById('projName').value = '';
+    document.getElementById('projDesc').value = '';
+    document.getElementById('projDir').value = '';
+    document.getElementById('projSsh').value = '';
+    document.getElementById('projMd').value = '';
+    document.getElementById('projRepos').value = '';
+    editId.value = '';
+    form.classList.toggle('open');
+  }
+}
+
+async function saveProject() {
+  const name = document.getElementById('projName').value.trim();
+  if (!name) return alert('Project name is required');
+  const body = {
+    name,
+    description: document.getElementById('projDesc').value.trim(),
+    mainDir: document.getElementById('projDir').value.trim(),
+    sshLocations: document.getElementById('projSsh').value.split(',').map(s => s.trim()).filter(Boolean),
+    claudeMdPaths: document.getElementById('projMd').value.split(',').map(s => s.trim()).filter(Boolean),
+    githubRepos: document.getElementById('projRepos').value.split(',').map(s => s.trim()).filter(Boolean),
+  };
+  const editId = document.getElementById('projEditId').value;
+  if (editId) {
+    await api('/api/projects/' + editId, { method: 'PUT', body });
+  } else {
+    await api('/api/projects', { method: 'POST', body });
+  }
+  document.getElementById('addProjectForm').classList.remove('open');
+  document.getElementById('projEditId').value = '';
+  loadProjectsList();
+}
+
+async function deleteProject(id) {
+  const proj = projects.find(p => p.id === id);
+  if (!confirm('Delete project "' + (proj?.name || id) + '"? Tasks will be unassigned.')) return;
+  await api('/api/projects/' + id, { method: 'DELETE' });
+  loadProjectsList();
+  loadTaskList();
+}
+
+function renderProjectCards() {
+  const container = document.getElementById('projectCards');
+  const unassigned = document.getElementById('unassignedTasks');
+  if (!container) return;
+  updateTabBadges();
+
+  if (projects.length === 0) {
+    container.innerHTML = '<div style="color:var(--text2);font-size:13px;padding:24px 0;text-align:center">' +
+      '<p style="margin-bottom:8px">No projects configured yet.</p>' +
+      '<p style="font-size:12px;color:var(--text3)">Click "+ New Project" to group tasks by codebase.</p></div>';
+    unassigned.style.display = 'none';
+    return;
+  }
+
+  const activityColors = { active: 'var(--green)', idle: 'var(--orange)', complete: 'var(--accent)', empty: 'var(--text3)' };
+  const activityLabels = { active: 'Active', idle: 'Idle', complete: 'Complete', empty: 'No tasks' };
+
+  container.innerHTML = projects.map(p => {
+    const color = activityColors[p.activityStatus] || 'var(--text3)';
+    const label = activityLabels[p.activityStatus] || 'Unknown';
+    const ptasks = p.tasks || [];
+
+    // Meta tags
+    let metaHtml = '';
+    if (p.mainDir) metaHtml += '<span class="project-meta-tag dir">\\ud83d\\udcc1 ' + esc(p.mainDir) + '</span>';
+    (p.sshLocations || []).forEach(s => { metaHtml += '<span class="project-meta-tag ssh">\\ud83d\\udd17 ' + esc(s) + '</span>'; });
+    (p.claudeMdPaths || []).forEach(m => { metaHtml += '<span class="project-meta-tag md">\\ud83d\\udcdd ' + esc(m.split('/').pop()) + '</span>'; });
+    (p.githubRepos || []).forEach(r => {
+      const url = r.startsWith('http') ? r : 'https://github.com/' + r;
+      const display = r.replace(/^https?:\\/\\/github\\.com\\//, '');
+      metaHtml += '<a class="project-meta-tag repo" href="' + esc(url) + '" target="_blank" style="text-decoration:none;cursor:pointer">\\u2693 ' + esc(display) + '</a>';
+    });
+
+    // Task list
+    let tasksHtml = '';
+    if (ptasks.length > 0) {
+      const running = ptasks.filter(t => t.status === 'running');
+      const pending = ptasks.filter(t => t.status === 'pending');
+      const done = ptasks.filter(t => t.status === 'completed');
+      const failed = ptasks.filter(t => t.status === 'failed');
+      const ordered = [...running, ...pending, ...failed, ...done];
+      tasksHtml = '<div class="project-tasks"><h4>' + ptasks.length + ' task' + (ptasks.length !== 1 ? 's' : '') +
+        ' \\u2014 ' + running.length + ' running, ' + pending.length + ' pending, ' + done.length + ' done' +
+        (failed.length ? ', ' + failed.length + ' failed' : '') + '</h4>' +
+        ordered.slice(0, 10).map(t =>
+          '<div class="project-task-row">' +
+            '<span class="dot ' + t.status + '"></span>' +
+            '<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(t.title) + '</span>' +
+            (t.approved ? '<span style="color:var(--green);font-size:10px">\\u2713</span>' : '<span style="color:var(--text3);font-size:10px">\\u2717</span>') +
+          '</div>'
+        ).join('') +
+        (ordered.length > 10 ? '<div style="font-size:11px;color:var(--text3);margin-top:4px">+ ' + (ordered.length - 10) + ' more</div>' : '') +
+        '</div>';
+    }
+
+    return '<div class="project-card ' + p.activityStatus + '">' +
+      '<div class="project-header">' +
+        '<div class="project-name"><span class="activity-dot" style="background:' + color + '"></span> ' + esc(p.name) + ' <span style="font-size:11px;font-weight:400;color:' + color + '">' + label + '</span></div>' +
+        '<div class="project-actions">' +
+          '<button class="btn btn-sm" onclick="editProject(\\'' + p.id + '\\')">Edit</button>' +
+          '<button class="btn btn-sm btn-danger" onclick="deleteProject(\\'' + p.id + '\\')">\\u00d7</button>' +
+        '</div>' +
+      '</div>' +
+      (p.description ? '<div class="project-desc">' + esc(p.description) + '</div>' : '') +
+      (metaHtml ? '<div class="project-meta">' + metaHtml + '</div>' : '') +
+      tasksHtml +
+    '</div>';
+  }).join('');
+
+  // Unassigned tasks section
+  const unassignedTasks = tasks.filter(t => !t.project);
+  if (unassignedTasks.length > 0) {
+    unassigned.style.display = 'block';
+    unassigned.innerHTML = '<h3>Unassigned Tasks (' + unassignedTasks.length + ')</h3>' +
+      unassignedTasks.map(t =>
+        '<div class="project-task-row" style="padding:6px 0">' +
+          '<span class="dot ' + t.status + '"></span>' +
+          '<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(t.title) + '</span>' +
+          '<select style="font-size:11px;padding:2px 6px;background:var(--bg3);border:1px solid var(--border);color:var(--text);border-radius:4px" onchange="assignTaskToProject(\\'' + t.id + '\\', this.value)">' +
+            '<option value="">Assign to...</option>' +
+            projects.map(p => '<option value="' + p.id + '">' + esc(p.name) + '</option>').join('') +
+          '</select>' +
+        '</div>'
+      ).join('');
+  } else {
+    unassigned.style.display = 'none';
+  }
+}
+
+function editProject(id) {
+  const proj = projects.find(p => p.id === id);
+  if (proj) toggleProjectForm(proj);
+}
+
+async function assignTaskToProject(taskId, projectId) {
+  await api('/api/tasks/' + taskId, { method: 'PUT', body: { project: projectId || null } });
+  loadProjectsList();
+  loadTaskList();
+}
+
+// ─── Locations (Sessions) ───
+let sessions = [];
+async function loadSessions() {
+  sessions = await api('/api/sessions');
+  renderLocations();
+}
+
+function renderLocations() {
+  const list = document.getElementById('locationsList');
+  const countEl = document.getElementById('locCount');
+  const badge = document.getElementById('locationBadge');
+  if (!list) return;
+
+  const running = sessions.filter(s => s.isRunning && !s.isArchived);
+  const recent = sessions.filter(s => !s.isRunning && !s.isArchived);
+  const archived = sessions.filter(s => s.isArchived);
+
+  if (badge) badge.textContent = running.length;
+  if (countEl) countEl.textContent = '(' + running.length + ' running, ' + sessions.length + ' total)';
+
+  if (sessions.length === 0) {
+    list.innerHTML = '<div style="color:var(--text2);font-size:13px;padding:24px 0;text-align:center">' +
+      '<p>No Claude Code sessions found.</p>' +
+      '<p style="font-size:12px;color:var(--text3);margin-top:4px">Sessions from the Claude Desktop app will appear here.</p></div>';
+    return;
+  }
+
+  let html = '';
+
+  if (running.length > 0) {
+    html += '<div class="loc-group"><h3>\\ud83d\\udfe2 Running <span class="count">(' + running.length + ')</span></h3>' +
+      running.map(locCardHtml).join('') + '</div>';
+  }
+
+  if (recent.length > 0) {
+    html += '<div class="loc-group"><h3>\\u23f8\\ufe0f Recent <span class="count">(' + recent.length + ')</span></h3>' +
+      recent.slice(0, 20).map(locCardHtml).join('') +
+      (recent.length > 20 ? '<div style="font-size:11px;color:var(--text3);padding:4px 0">+ ' + (recent.length - 20) + ' more</div>' : '') +
+      '</div>';
+  }
+
+  if (archived.length > 0) {
+    html += '<div class="loc-group"><h3>\\ud83d\\udce6 Archived <span class="count">(' + archived.length + ')</span></h3>' +
+      archived.slice(0, 10).map(locCardHtml).join('') +
+      (archived.length > 10 ? '<div style="font-size:11px;color:var(--text3);padding:4px 0">+ ' + (archived.length - 10) + ' more</div>' : '') +
+      '</div>';
+  }
+
+  list.innerHTML = html;
+}
+
+function locCardHtml(s) {
+  const statusClass = s.isRunning ? 'running' : s.isArchived ? 'archived' : 'idle';
+  const statusLabel = s.isRunning ? 'Running' : s.isArchived ? 'Archived' : 'Idle';
+  const timeAgo = s.lastActivityAt ? relativeTime(s.lastActivityAt) : '';
+  const modelShort = (s.model || '').replace('claude-', '').replace(/-/g, ' ');
+
+  return '<div class="loc-card ' + statusClass + '">' +
+    '<span class="loc-status ' + statusClass + '"></span>' +
+    '<div class="loc-info">' +
+      '<div class="loc-title">' + esc(s.title || 'Untitled') + '</div>' +
+      '<div class="loc-detail">' +
+        '<span>\\ud83d\\udcc1 ' + esc(s.project || 'Unknown') + '</span>' +
+        '<span>' + esc(s.cwd || '') + '</span>' +
+        (timeAgo ? '<span>' + timeAgo + '</span>' : '') +
+      '</div>' +
+    '</div>' +
+    '<div class="loc-tags">' +
+      '<span class="loc-tag status-' + statusClass + '">' + statusLabel + '</span>' +
+      (modelShort ? '<span class="loc-tag model">' + esc(modelShort) + '</span>' : '') +
+      (s.permissionMode ? '<span class="loc-tag perm">' + esc(s.permissionMode) + '</span>' : '') +
+    '</div>' +
+  '</div>';
+}
+
+function relativeTime(iso) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return mins + 'm ago';
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return hrs + 'h ago';
+  const days = Math.floor(hrs / 24);
+  return days + 'd ago';
+}
+
+// ─── Usage Monitor ───
+async function loadUsage() {
+  const data = await api('/api/usage');
+  renderUsage(data);
+  renderOvernightQueue();
+}
+
+function updateConnectionStatus(data) {
+  const dot = document.getElementById('connDot');
+  const text = document.getElementById('connText');
+  if (!dot || !text) return;
+
+  if (data?.current) {
+    dot.style.background = 'var(--green)';
+    const ts = data.lastUpdated ? new Date(data.lastUpdated).toLocaleTimeString() : 'just now';
+    text.textContent = 'Connected \\u2014 last updated ' + ts;
+    text.style.color = 'var(--green)';
+  } else {
+    dot.style.background = 'var(--red)';
+    text.textContent = 'Not connected \\u2014 configure session cookie to enable monitoring';
+    text.style.color = 'var(--red)';
+  }
+}
+
+function renderResetTimers(data) {
+  const el = document.getElementById('resetTimers');
+  if (!el || !data?.current) return;
+  const c = data.current;
+  let html = '';
+  if (c.fiveHour?.resetsIn) html += '<p>5-Hour Window: resets in <strong>' + c.fiveHour.resetsIn + '</strong></p>';
+  if (c.sevenDay?.resetsIn) html += '<p>Weekly Limit: resets in <strong>' + c.sevenDay.resetsIn + '</strong></p>';
+  el.innerHTML = html || '<p>No reset data available</p>';
+}
+
+function renderOvernightQueue() {
+  const el = document.getElementById('overnightQueue');
+  if (!el) return;
+  const approvedPending = tasks.filter(t => t.approved && t.status === 'pending')
+    .sort((a, b) => (a.order || 0) - (b.order || 0));
+  if (approvedPending.length === 0) {
+    el.innerHTML = '<p>No approved tasks in queue</p>';
+    return;
+  }
+  el.innerHTML = '<ol style="margin:0;padding-left:20px">' +
+    approvedPending.map(t => {
+      const proj = t.project ? projects.find(p => p.id === t.project) : null;
+      return '<li style="margin-bottom:4px">' + esc(t.title) +
+        (proj ? ' <span style="color:var(--accent);font-size:11px">[' + esc(proj.name) + ']</span>' : '') +
+        ' <span style="color:var(--text3);font-size:11px">' + esc(t.dir) + '</span></li>';
+    }).join('') + '</ol>';
+}
+
+function saveScheduleFromUsage() {
+  const bed = document.getElementById('usageBedTime').value;
+  const wake = document.getElementById('usageWakeTime').value;
+  const work = document.getElementById('usageWorkTime').value;
+  // Sync to header inputs too
+  document.getElementById('bedTime').value = bed;
+  document.getElementById('wakeTime').value = wake;
+  document.getElementById('workTime').value = work;
+  api('/api/schedule', { method: 'POST', body: { bedTime: bed, wakeTime: wake, workTime: work } });
+}
+
+function renderUsage(data) {
+  const grid = document.getElementById('usageGrid');
+  updateConnectionStatus(data);
+  renderResetTimers(data);
+  if (!data || !data.current) {
+    grid.innerHTML = '<div class="usage-card"><h3>No usage data</h3><p class="usage-detail">Configure your session cookie to enable monitoring</p></div>';
+    return;
+  }
+  const c = data.current;
+  let html = '';
+
+  // 5-hour window
+  if (c.fiveHour) {
+    html += usageCardHtml('5-Hour Window', c.fiveHour.utilization, c.fiveHour.resetsIn ? 'Resets in ' + c.fiveHour.resetsIn : '');
+  }
+
+  // 7-day all models
+  if (c.sevenDay) {
+    html += usageCardHtml('Weekly (All Models)', c.sevenDay.utilization, c.sevenDay.resetsIn ? 'Resets in ' + c.sevenDay.resetsIn : '');
+  }
+
+  // Sonnet
+  if (c.sonnet && c.sonnet.utilization !== undefined) {
+    html += usageCardHtml('Weekly (Sonnet)', c.sonnet.utilization, '');
+  }
+
+  // Extra usage
+  if (c.extraUsage) {
+    const cur = c.extraUsage.currency || 'AUD';
+    const used = (c.extraUsage.used / 100).toFixed(2);
+    const limit = (c.extraUsage.limit / 100).toFixed(2);
+    html += '<div class="usage-card">' +
+      '<h3>Extra Usage</h3>' +
+      '<div class="usage-bar"><div class="usage-bar-fill purple" style="width:' + c.extraUsage.percentage + '%"></div></div>' +
+      '<div style="display:flex;justify-content:space-between;align-items:baseline">' +
+        '<span class="usage-percent">' + c.extraUsage.percentage + '%</span>' +
+        '<span class="usage-detail">' + cur + ' $' + used + ' / $' + limit + '</span>' +
+      '</div>' +
+      (c.prepaid ? '<div class="usage-detail" style="margin-top:4px">Balance: ' + cur + ' $' + (c.prepaid.amount / 100).toFixed(2) + '</div>' : '') +
+    '</div>';
+  }
+
+  grid.innerHTML = html;
+
+  // Chart
+  if (data.graph?.polls?.length > 1) {
+    renderUsageChart(data.graph);
+  }
+}
+
+function usageCardHtml(title, pct, subtitle) {
+  const col = usageColor(pct);
+  return '<div class="usage-card">' +
+    '<h3>' + title + '<span class="usage-detail">' + esc(subtitle) + '</span></h3>' +
+    '<div class="usage-bar"><div class="usage-bar-fill ' + col + '" style="width:' + pct + '%"></div></div>' +
+    '<span class="usage-percent">' + pct + '%</span>' +
+  '</div>';
+}
+
+function renderUsageChart(graph) {
+  const chart = document.getElementById('usageChart');
+  chart.style.display = 'block';
+  const polls = graph.polls;
+  const events = graph.taskEvents || [];
+  if (polls.length < 2) return;
+
+  const w = 600, h = 100, pad = 30;
+  const minT = new Date(polls[0].ts).getTime();
+  const maxT = new Date(polls[polls.length - 1].ts).getTime();
+  const range = maxT - minT || 1;
+
+  const scaleX = (ts) => pad + ((new Date(ts).getTime() - minT) / range) * (w - pad * 2);
+  const scaleY = (v) => h - pad + (pad - (h - pad)) * (v / 100);
+
+  let pathD = polls.map((p, i) => (i === 0 ? 'M' : 'L') + scaleX(p.ts).toFixed(1) + ',' + scaleY(p.fiveHr ?? 0).toFixed(1)).join(' ');
+
+  let markers = events.map(e => {
+    const x = scaleX(e.ts);
+    const color = e.event === 'task_start' ? 'var(--orange)' : 'var(--green)';
+    const r = e.event === 'task_start' ? 4 : 3;
+    return '<circle cx="' + x.toFixed(1) + '" cy="' + (h / 2) + '" r="' + r + '" fill="' + color + '" />' +
+           '<text x="' + x.toFixed(1) + '" y="' + (h / 2 + 14) + '" fill="var(--text3)" font-size="8" text-anchor="middle">' + esc(e.task || '').slice(0, 15) + '</text>';
+  }).join('');
+
+  chart.innerHTML = '<svg viewBox="0 0 ' + w + ' ' + (h + 10) + '" xmlns="http://www.w3.org/2000/svg">' +
+    '<line x1="' + pad + '" y1="' + (h - pad) + '" x2="' + (w - pad) + '" y2="' + (h - pad) + '" stroke="var(--border)" />' +
+    '<line x1="' + pad + '" y1="' + pad + '" x2="' + pad + '" y2="' + (h - pad) + '" stroke="var(--border)" />' +
+    '<text x="' + pad + '" y="' + (pad - 5) + '" fill="var(--text3)" font-size="9">100%</text>' +
+    '<text x="' + pad + '" y="' + (h - pad + 12) + '" fill="var(--text3)" font-size="9">0%</text>' +
+    '<path d="' + pathD + '" fill="none" stroke="var(--accent)" stroke-width="2" />' +
+    markers +
+  '</svg>';
+}
+
+// ─── Status ───
+async function loadStatus() {
+  const status = await api('/api/status');
+  const badge = document.getElementById('statusBadge');
+  const text = document.getElementById('statusText');
+  const credit = document.getElementById('creditStatus');
+  const btn = document.getElementById('startStopBtn');
+
+  const mode = status.schedule?.currentMode || 'WORK';
+  badge.className = 'status-badge status-' + mode;
+  text.textContent = mode;
+
+  if (status.runner?.isRunning) {
+    credit.textContent = 'Running: ' + (status.runner.currentTask || '');
+  } else if (status.creditsAvailable) {
+    credit.textContent = 'Credits available';
+  } else {
+    credit.textContent = status.schedule?.running ? 'Waiting for credits...' : '';
+  }
+
+  btn.textContent = status.schedule?.running ? 'Stop' : 'Start';
+  btn.className = status.schedule?.running ? 'btn btn-danger' : 'btn btn-primary';
+
+  // Populate schedule inputs (header + usage tab)
+  if (status.schedule) {
+    document.getElementById('bedTime').value = status.schedule.bedTime || '23:00';
+    document.getElementById('wakeTime').value = status.schedule.wakeTime || '07:00';
+    document.getElementById('workTime').value = status.schedule.workTime || '09:00';
+    const ub = document.getElementById('usageBedTime');
+    const uw = document.getElementById('usageWakeTime');
+    const uwk = document.getElementById('usageWorkTime');
+    if (ub) ub.value = status.schedule.bedTime || '23:00';
+    if (uw) uw.value = status.schedule.wakeTime || '07:00';
+    if (uwk) uwk.value = status.schedule.workTime || '09:00';
+  }
+}
+
+// ─── Config ───
+async function loadApiConfig() {
+  const data = await api('/api/config');
+  window._cachedConfig = data;
+  if (data.claudeApi?.orgId) document.getElementById('orgIdInput').value = data.claudeApi.orgId;
+  if (data.claudeApi?.sessionKeySet) document.getElementById('sessionKeyInput').placeholder = 'Cookie saved (hidden)';
+}
+
+async function saveApiConfig() {
+  const sessionKey = document.getElementById('sessionKeyInput').value.trim();
+  const orgId = document.getElementById('orgIdInput').value.trim();
+  const body = { claudeApi: {} };
+  if (sessionKey) body.claudeApi.sessionKey = sessionKey;
+  if (orgId) body.claudeApi.orgId = orgId;
+  await api('/api/config', { method: 'POST', body });
+  document.getElementById('sessionKeyInput').value = '';
+  document.getElementById('sessionKeyInput').placeholder = 'Cookie saved (hidden)';
+  refreshUsage();
+}
+
+async function refreshUsage() { loadUsage(); }
+
+// ─── Daemon control ───
+async function toggleDaemon() {
+  const status = await api('/api/status');
+  if (status.schedule?.running) {
+    await api('/api/daemon/stop', { method: 'POST' });
+  } else {
+    await api('/api/schedule', { method: 'POST', body: {
+      bedTime: document.getElementById('bedTime').value,
+      wakeTime: document.getElementById('wakeTime').value,
+      workTime: document.getElementById('workTime').value,
+    }});
+    await api('/api/daemon/start', { method: 'POST' });
+  }
+  setTimeout(loadStatus, 500);
+}
+
+// ─── Log ───
+async function loadLog() {
+  const lines = await api('/api/log?lines=80');
+  document.getElementById('logOutput').textContent = Array.isArray(lines) ? lines.join('\\n') : 'No logs yet';
+}
+
+// ─── Summary ───
+async function loadSummary() {
+  const data = await api('/api/summary');
+  document.getElementById('summaryContent').textContent = data.content || 'No summary available yet.';
+}
+
+// ─── Init & Polling ───
+async function init() {
+  initTabFromHash();
+  window.addEventListener('hashchange', initTabFromHash);
+  await Promise.all([loadStatus(), loadTaskList(), loadProfiles(), loadProjectsList(), loadSessions(), loadApiConfig(), loadUsage(), loadLog(), loadSummary()]);
+  // Poll every 5 seconds
+  setInterval(() => { loadStatus(); loadTaskList(); }, 5000);
+  setInterval(loadProjectsList, 30000);
+  setInterval(loadSessions, 15000);
+  setInterval(loadLog, 10000);
+  setInterval(loadUsage, 60000);
+}
+
+init();
+</script>
+</body>
+</html>`;
+}

--- a/packages/server/index.mjs
+++ b/packages/server/index.mjs
@@ -1,0 +1,2 @@
+export { startServer, setDaemon } from './server.mjs';
+export { getDashboardHtml } from './dashboard.mjs';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@autoclaude/server",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs",
+  "dependencies": {
+    "@autoclaude/core": "1.0.0",
+    "@autoclaude/store": "1.0.0",
+    "@autoclaude/sessions": "1.0.0"
+  }
+}

--- a/packages/server/server.mjs
+++ b/packages/server/server.mjs
@@ -1,0 +1,225 @@
+import { createServer } from 'node:http';
+import { loadConfig, saveConfig, getRecentLogs, log } from '@autoclaude/core';
+import { loadTasks, createTask, updateTask, deleteTask, reorderTasks, loadPermissions, createPermissionProfile, updatePermissionProfile, deletePermissionProfile, listProjects, getProject, createProject, updateProject, deleteProject, getLatestSummary } from '@autoclaude/store';
+import { scanActiveSessions } from '@autoclaude/sessions';
+import { getDashboardHtml } from './dashboard.mjs';
+
+let _daemon = null; // set by bin/autoclaude.mjs
+
+export function setDaemon(daemon) {
+  _daemon = daemon;
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => { data += chunk; });
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch {
+        reject(new Error('Invalid JSON'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function json(res, data, status = 200) {
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
+  res.end(JSON.stringify(data));
+}
+
+function extractParam(url, prefix) {
+  const path = url.split('?')[0];
+  const after = path.slice(prefix.length);
+  return after.startsWith('/') ? after.slice(1) : after;
+}
+
+export function startServer() {
+  const config = loadConfig();
+  const { port, host } = config.server;
+
+  const server = createServer(async (req, res) => {
+    const url = req.url;
+    const method = req.method;
+
+    // CORS preflight
+    if (method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      });
+      res.end();
+      return;
+    }
+
+    try {
+      // Dashboard HTML
+      if (url === '/' && method === 'GET') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(getDashboardHtml());
+        return;
+      }
+
+      // ─── Tasks ───
+      if (url === '/api/tasks' && method === 'GET') {
+        return json(res, loadTasks());
+      }
+      if (url === '/api/tasks' && method === 'POST') {
+        const body = await parseBody(req);
+        const task = createTask(body);
+        return json(res, task, 201);
+      }
+      if (url === '/api/tasks/reorder' && method === 'PUT') {
+        const body = await parseBody(req);
+        const tasks = reorderTasks(body.orderedIds);
+        return json(res, tasks);
+      }
+      if (url.startsWith('/api/tasks/') && method === 'PUT') {
+        const id = extractParam(url, '/api/tasks/');
+        const body = await parseBody(req);
+        const task = updateTask(id, body);
+        return task ? json(res, task) : json(res, { error: 'Not found' }, 404);
+      }
+      if (url.startsWith('/api/tasks/') && method === 'DELETE') {
+        const id = extractParam(url, '/api/tasks/');
+        return deleteTask(id) ? json(res, { ok: true }) : json(res, { error: 'Not found' }, 404);
+      }
+
+      // ─── Permissions ───
+      if (url === '/api/permissions' && method === 'GET') {
+        return json(res, loadPermissions());
+      }
+      if (url === '/api/permissions' && method === 'POST') {
+        const body = await parseBody(req);
+        const profile = createPermissionProfile(body.key, body.profile);
+        return json(res, profile, 201);
+      }
+      if (url.startsWith('/api/permissions/') && method === 'PUT') {
+        const key = extractParam(url, '/api/permissions/');
+        const body = await parseBody(req);
+        const profile = updatePermissionProfile(key, body);
+        return profile ? json(res, profile) : json(res, { error: 'Not found' }, 404);
+      }
+      if (url.startsWith('/api/permissions/') && method === 'DELETE') {
+        const key = extractParam(url, '/api/permissions/');
+        return deletePermissionProfile(key) ? json(res, { ok: true }) : json(res, { error: 'Not found' }, 404);
+      }
+
+      // ─── Projects ───
+      if (url === '/api/projects' && method === 'GET') {
+        return json(res, listProjects());
+      }
+      if (url === '/api/projects' && method === 'POST') {
+        const body = await parseBody(req);
+        const project = createProject(body);
+        return json(res, project, 201);
+      }
+      if (url.startsWith('/api/projects/') && method === 'GET') {
+        const id = extractParam(url, '/api/projects/');
+        const project = getProject(id);
+        return project ? json(res, project) : json(res, { error: 'Not found' }, 404);
+      }
+      if (url.startsWith('/api/projects/') && method === 'PUT') {
+        const id = extractParam(url, '/api/projects/');
+        const body = await parseBody(req);
+        const project = updateProject(id, body);
+        return project ? json(res, project) : json(res, { error: 'Not found' }, 404);
+      }
+      if (url.startsWith('/api/projects/') && method === 'DELETE') {
+        const id = extractParam(url, '/api/projects/');
+        return deleteProject(id) ? json(res, { ok: true }) : json(res, { error: 'Not found' }, 404);
+      }
+
+      // ─── Status ───
+      if (url === '/api/status' && method === 'GET') {
+        return json(res, _daemon?.getStatus() || { mode: 'WORK', running: false });
+      }
+
+      // ─── Schedule ───
+      if (url === '/api/schedule' && method === 'POST') {
+        const body = await parseBody(req);
+        if (_daemon) _daemon.setSchedule(body);
+        saveConfig({ schedule: body });
+        return json(res, { ok: true });
+      }
+
+      // ─── Daemon control ───
+      if (url === '/api/daemon/start' && method === 'POST') {
+        if (_daemon) _daemon.start();
+        return json(res, { ok: true });
+      }
+      if (url === '/api/daemon/stop' && method === 'POST') {
+        if (_daemon) _daemon.stop();
+        return json(res, { ok: true });
+      }
+
+      // ─── Sessions (active Claude Code instances) ───
+      if (url === '/api/sessions' && method === 'GET') {
+        return json(res, scanActiveSessions());
+      }
+
+      // ─── Usage ───
+      if (url === '/api/usage' && method === 'GET') {
+        return json(res, _daemon?.getUsageData() || {});
+      }
+
+      // ─── Auth: extract cookies from browser login ───
+      if (url === '/api/auth/callback' && method === 'POST') {
+        const body = await parseBody(req);
+        if (body.sessionKey && body.orgId) {
+          saveConfig({ claudeApi: { sessionKey: body.sessionKey, orgId: body.orgId } });
+          log('info', 'Session cookie saved via browser login');
+          return json(res, { ok: true });
+        }
+        return json(res, { error: 'Missing sessionKey or orgId' }, 400);
+      }
+
+      // ─── Config (session key, org ID) ───
+      if (url === '/api/config' && method === 'GET') {
+        const config = loadConfig();
+        return json(res, {
+          claudeApi: {
+            orgId: config.claudeApi.orgId,
+            sessionKeySet: !!config.claudeApi.sessionKey,
+          },
+          schedule: config.schedule,
+          creditCheck: { utilizationThreshold: config.creditCheck.utilizationThreshold },
+        });
+      }
+      if (url === '/api/config' && method === 'POST') {
+        const body = await parseBody(req);
+        saveConfig(body);
+        return json(res, { ok: true });
+      }
+
+      // ─── Log ───
+      if (url.startsWith('/api/log') && method === 'GET') {
+        const params = new URL(url, 'http://localhost').searchParams;
+        const lines = parseInt(params.get('lines')) || 50;
+        return json(res, getRecentLogs(lines));
+      }
+
+      // ─── Summary ───
+      if (url === '/api/summary' && method === 'GET') {
+        const summary = getLatestSummary();
+        return json(res, { content: summary });
+      }
+
+      // 404
+      json(res, { error: 'Not found' }, 404);
+
+    } catch (err) {
+      log('error', `Server error: ${err.message}`);
+      json(res, { error: err.message }, 500);
+    }
+  });
+
+  server.listen(port, host, () => {
+    log('info', `Dashboard running at http://${host}:${port}`);
+  });
+
+  return server;
+}

--- a/packages/sessions/CLAUDE.md
+++ b/packages/sessions/CLAUDE.md
@@ -1,0 +1,27 @@
+# @autoclaude/sessions
+
+macOS-specific Claude Code session scanning. Reads Desktop app JSON files, detects running processes, and parses session JSONL files.
+
+## Scope
+
+- **Session Tracker** (`session-tracker.mjs`) — scans `~/Library/Application Support/Claude/claude-code-sessions/` for desktop app metadata, `~/.claude/projects/` for session JSONL files, and `~/.claude/todos/` for todo files. Detects running sessions via `ps aux`.
+
+## Dependencies
+
+None. This package has zero dependencies on other `@autoclaude/*` packages or Node.js modules beyond built-ins (`node:fs`, `node:path`, `node:os`, `node:child_process`).
+
+## Key Exports
+
+```js
+encodeProjectPath(dirPath) → string
+getSessionMessages(sessionId, projectDir) → Message[]
+getSessionSummary(sessionId, projectDir) → SessionSummary
+scanActiveSessions() → Session[]
+getSessionTodos(sessionId) → Todo[]
+```
+
+## Platform Notes
+
+- This package is macOS-specific (reads from `~/Library/Application Support/`)
+- `ps aux` parsing for running session detection
+- V2/V3 changes (session interaction, remote execution) will primarily impact this package

--- a/packages/sessions/index.mjs
+++ b/packages/sessions/index.mjs
@@ -1,0 +1,1 @@
+export { encodeProjectPath, getSessionMessages, getSessionSummary, scanActiveSessions, getSessionTodos } from './session-tracker.mjs';

--- a/packages/sessions/package.json
+++ b/packages/sessions/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@autoclaude/sessions",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/packages/sessions/session-tracker.mjs
+++ b/packages/sessions/session-tracker.mjs
@@ -1,0 +1,182 @@
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { homedir } from 'node:os';
+import { execSync } from 'node:child_process';
+
+const CLAUDE_DIR = join(homedir(), '.claude');
+const DESKTOP_SESSIONS_DIR = join(homedir(), 'Library', 'Application Support', 'Claude', 'claude-code-sessions');
+
+export function encodeProjectPath(dirPath) {
+  return dirPath.replace(/\//g, '-');
+}
+
+export function getSessionMessages(sessionId, projectDir) {
+  const encodedPath = encodeProjectPath(projectDir);
+  const sessionFile = join(CLAUDE_DIR, 'projects', encodedPath, `${sessionId}.jsonl`);
+
+  if (!existsSync(sessionFile)) return [];
+
+  const content = readFileSync(sessionFile, 'utf8');
+  return content.split('\n')
+    .filter(Boolean)
+    .map(line => { try { return JSON.parse(line); } catch { return null; } })
+    .filter(Boolean);
+}
+
+export function getSessionSummary(sessionId, projectDir) {
+  const messages = getSessionMessages(sessionId, projectDir);
+
+  const toolUses = {};
+  const subagentCalls = [];
+  const models = new Set();
+  let lastText = '';
+
+  for (const msg of messages) {
+    if (msg.type === 'assistant') {
+      if (msg.model) models.add(msg.model);
+      const content = msg.message?.content || [];
+      for (const block of content) {
+        if (block.type === 'tool_use') {
+          const name = block.name || 'unknown';
+          toolUses[name] = (toolUses[name] || 0) + 1;
+          if (name === 'Task') {
+            subagentCalls.push({
+              description: block.input?.description || '',
+              subagentType: block.input?.subagent_type || block.input?.subagentType || 'unknown',
+              model: block.input?.model || 'inherited',
+            });
+          }
+        }
+        if (block.type === 'text') {
+          lastText = block.text;
+        }
+      }
+    }
+  }
+
+  const totalToolUses = Object.values(toolUses).reduce((a, b) => a + b, 0);
+
+  return {
+    sessionId,
+    projectDir,
+    messageCount: messages.length,
+    toolUses,
+    totalToolUses,
+    subagentCalls,
+    subagentCount: subagentCalls.length,
+    models: [...models],
+    claudeDirectWork: totalToolUses - subagentCalls.length,
+    subagentRatio: totalToolUses > 0 ? subagentCalls.length / totalToolUses : 0,
+    lastResponse: lastText.slice(0, 500),
+    startTime: messages[0]?.timestamp,
+    endTime: messages[messages.length - 1]?.timestamp,
+  };
+}
+
+// ─── Active Sessions Scanner ───
+
+export function scanActiveSessions() {
+  const sessions = [];
+
+  // 1. Read desktop app session metadata
+  const desktopSessions = readDesktopSessions();
+
+  // 2. Get running claude processes to detect truly active ones
+  const runningSessionIds = getRunningSessionIds();
+
+  // 3. Merge desktop metadata with running status
+  for (const ds of desktopSessions) {
+    const isRunning = runningSessionIds.has(ds.cliSessionId);
+    sessions.push({
+      id: ds.sessionId,
+      cliSessionId: ds.cliSessionId,
+      title: ds.title || 'Untitled',
+      project: extractProjectName(ds.cwd),
+      cwd: ds.cwd,
+      model: ds.model,
+      permissionMode: ds.permissionMode,
+      isArchived: ds.isArchived,
+      isRunning,
+      createdAt: ds.createdAt ? new Date(ds.createdAt).toISOString() : null,
+      lastActivityAt: ds.lastActivityAt ? new Date(ds.lastActivityAt).toISOString() : null,
+      todos: [],
+    });
+  }
+
+  // 4. Sort: running first, then by lastActivityAt descending
+  sessions.sort((a, b) => {
+    if (a.isRunning !== b.isRunning) return a.isRunning ? -1 : 1;
+    const aTime = a.lastActivityAt ? new Date(a.lastActivityAt).getTime() : 0;
+    const bTime = b.lastActivityAt ? new Date(b.lastActivityAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  return sessions;
+}
+
+function readDesktopSessions() {
+  if (!existsSync(DESKTOP_SESSIONS_DIR)) return [];
+
+  const sessions = [];
+  try {
+    // Traverse accountUuid/orgUuid directories
+    for (const accountDir of readdirSync(DESKTOP_SESSIONS_DIR)) {
+      const accountPath = join(DESKTOP_SESSIONS_DIR, accountDir);
+      if (!statSync(accountPath).isDirectory()) continue;
+
+      for (const orgDir of readdirSync(accountPath)) {
+        const orgPath = join(accountPath, orgDir);
+        if (!statSync(orgPath).isDirectory()) continue;
+
+        for (const file of readdirSync(orgPath)) {
+          if (!file.endsWith('.json')) continue;
+          try {
+            const content = readFileSync(join(orgPath, file), 'utf8');
+            const data = JSON.parse(content);
+            sessions.push(data);
+          } catch { /* skip corrupt files */ }
+        }
+      }
+    }
+  } catch { /* directory traversal failed */ }
+
+  return sessions;
+}
+
+function getRunningSessionIds() {
+  const running = new Set();
+  try {
+    const output = execSync('ps aux', { encoding: 'utf8', timeout: 5000 });
+    // Look for claude processes with --resume or --session-id flags
+    for (const line of output.split('\n')) {
+      if (!line.includes('claude')) continue;
+      // Match --resume UUID or --session-id UUID
+      const resumeMatch = line.match(/--resume\s+([a-f0-9-]{36})/);
+      if (resumeMatch) running.add(resumeMatch[1]);
+      const sessionMatch = line.match(/--session-id\s+([a-f0-9-]{36})/);
+      if (sessionMatch) running.add(sessionMatch[1]);
+    }
+  } catch { /* ps failed */ }
+  return running;
+}
+
+function extractProjectName(cwd) {
+  if (!cwd) return 'Unknown';
+  const parts = cwd.split('/');
+  return parts[parts.length - 1] || parts[parts.length - 2] || cwd;
+}
+
+export function getSessionTodos(sessionId) {
+  const todosDir = join(CLAUDE_DIR, 'todos');
+  if (!existsSync(todosDir)) return [];
+
+  const files = readdirSync(todosDir).filter(f => f.startsWith(sessionId));
+  const allTodos = [];
+  for (const file of files) {
+    try {
+      const content = readFileSync(join(todosDir, file), 'utf8');
+      allTodos.push(...JSON.parse(content));
+    } catch { /* skip */ }
+  }
+  return allTodos;
+}

--- a/packages/store/CLAUDE.md
+++ b/packages/store/CLAUDE.md
@@ -1,0 +1,41 @@
+# @autoclaude/store
+
+All JSON data persistence — tasks, permission profiles, projects, usage history, and overnight summaries.
+
+## Scope
+
+- **Task Queue** (`task-queue.mjs`) — CRUD for tasks (`~/.autoclaude/tasks.json`) and permission profiles (`~/.autoclaude/permissions.json`). Contains the task data model and three default permission profiles (full-auto, safe-edit, read-only).
+- **Projects** (`projects.mjs`) — CRUD for projects (`~/.autoclaude/projects.json`). Projects group tasks and have computed fields (activity status, running locations). Cascade-unassigns tasks on project deletion.
+- **Usage Monitor** (`usage-monitor.mjs`) — Records usage polling history (`~/.autoclaude/usage-history.json`, capped at 2000 entries). Transforms raw API data into dashboard-ready summaries.
+- **Summary** (`summary.mjs`) — Generates Markdown overnight summaries of completed/failed tasks to `~/.autoclaude/summaries/`.
+
+## Dependencies
+
+- `@autoclaude/core` — config for file paths
+- `@autoclaude/sessions` — summary.mjs uses `getSessionTodos()`
+
+## Key Exports
+
+```js
+// Tasks
+loadTasks, saveTasks, createTask, updateTask, deleteTask, reorderTasks, getNextApprovedTask
+
+// Permission Profiles
+loadPermissions, savePermissions, getPermissionProfile, createPermissionProfile, updatePermissionProfile, deletePermissionProfile
+
+// Projects
+loadProjects, saveProjects, createProject, getProject, updateProject, deleteProject, listProjects
+
+// Usage
+loadUsageHistory, appendUsageEvent, recordPoll, recordTaskEvent, getGraphData, getCurrentUsageSummary
+
+// Summary
+generateSummary, getLatestSummary
+```
+
+## Conventions
+
+- All persistence is JSON files in `~/.autoclaude/`
+- File paths come from `loadConfig().paths.*` — never hardcode
+- Task IDs and project IDs are UUIDs from `node:crypto`
+- Usage history capped at 2000 entries to prevent unbounded growth

--- a/packages/store/index.mjs
+++ b/packages/store/index.mjs
@@ -1,0 +1,14 @@
+// Tasks
+export { loadTasks, saveTasks, createTask, updateTask, deleteTask, reorderTasks, getNextApprovedTask } from './task-queue.mjs';
+
+// Permission Profiles
+export { loadPermissions, savePermissions, getPermissionProfile, createPermissionProfile, updatePermissionProfile, deletePermissionProfile } from './task-queue.mjs';
+
+// Projects
+export { loadProjects, saveProjects, createProject, getProject, updateProject, deleteProject, listProjects } from './projects.mjs';
+
+// Usage Monitor
+export { loadUsageHistory, appendUsageEvent, recordPoll, recordTaskEvent, getGraphData, getCurrentUsageSummary } from './usage-monitor.mjs';
+
+// Summary
+export { generateSummary, getLatestSummary } from './summary.mjs';

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@autoclaude/store",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs",
+  "dependencies": {
+    "@autoclaude/core": "1.0.0",
+    "@autoclaude/sessions": "1.0.0"
+  }
+}

--- a/packages/store/projects.mjs
+++ b/packages/store/projects.mjs
@@ -1,0 +1,110 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { loadConfig } from '@autoclaude/core';
+import { loadTasks } from './task-queue.mjs';
+
+// ─── Projects ───
+
+export function loadProjects() {
+  const config = loadConfig();
+  if (!existsSync(config.paths.projectsFile)) return [];
+  try {
+    return JSON.parse(readFileSync(config.paths.projectsFile, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+export function saveProjects(projects) {
+  const config = loadConfig();
+  writeFileSync(config.paths.projectsFile, JSON.stringify(projects, null, 2));
+}
+
+export function createProject({ name, description = '', mainDir = '', sshLocations = [], claudeMdPaths = [], permissions = {}, githubRepos = [] }) {
+  if (!name) throw new Error('Project name is required');
+  const projects = loadProjects();
+  const project = {
+    id: randomUUID(),
+    name,
+    description,
+    mainDir,
+    sshLocations,
+    claudeMdPaths,
+    permissions,
+    githubRepos,
+    created: new Date().toISOString(),
+    updated: new Date().toISOString(),
+  };
+  projects.push(project);
+  saveProjects(projects);
+  return project;
+}
+
+export function getProject(id) {
+  const projects = loadProjects();
+  const project = projects.find(p => p.id === id);
+  if (!project) return null;
+  return enrichProject(project);
+}
+
+export function updateProject(id, updates) {
+  const projects = loadProjects();
+  const idx = projects.findIndex(p => p.id === id);
+  if (idx === -1) return null;
+  // Don't allow overwriting id or created
+  delete updates.id;
+  delete updates.created;
+  updates.updated = new Date().toISOString();
+  Object.assign(projects[idx], updates);
+  saveProjects(projects);
+  return projects[idx];
+}
+
+export function deleteProject(id) {
+  const projects = loadProjects();
+  const idx = projects.findIndex(p => p.id === id);
+  if (idx === -1) return false;
+  projects.splice(idx, 1);
+  saveProjects(projects);
+  // Unassign tasks from this project
+  const tasks = loadTasks();
+  let changed = false;
+  for (const task of tasks) {
+    if (task.project === id) {
+      task.project = null;
+      changed = true;
+    }
+  }
+  if (changed) {
+    const config = loadConfig();
+    writeFileSync(config.paths.taskFile, JSON.stringify(tasks, null, 2));
+  }
+  return true;
+}
+
+export function listProjects() {
+  const projects = loadProjects();
+  return projects.map(enrichProject);
+}
+
+function enrichProject(project) {
+  const tasks = loadTasks();
+  const projectTasks = tasks.filter(t => t.project === project.id);
+  const runningTasks = projectTasks.filter(t => t.status === 'running');
+
+  let activityStatus = 'empty';
+  if (runningTasks.length > 0) {
+    activityStatus = 'active';
+  } else if (projectTasks.some(t => t.status === 'pending')) {
+    activityStatus = 'idle';
+  } else if (projectTasks.length > 0) {
+    activityStatus = 'complete';
+  }
+
+  return {
+    ...project,
+    tasks: projectTasks,
+    runningLocations: runningTasks.map(t => t.dir),
+    activityStatus,
+  };
+}

--- a/packages/store/summary.mjs
+++ b/packages/store/summary.mjs
@@ -1,0 +1,95 @@
+import { writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadConfig } from '@autoclaude/core';
+import { loadTasks } from './task-queue.mjs';
+import { getSessionSummary, getSessionTodos } from '@autoclaude/sessions';
+
+export function generateSummary(sessionStartTime) {
+  const config = loadConfig();
+  const tasks = loadTasks();
+
+  const tonight = tasks.filter(t =>
+    t.started && new Date(t.started) >= sessionStartTime &&
+    (t.status === 'completed' || t.status === 'failed')
+  );
+
+  const completed = tonight.filter(t => t.status === 'completed');
+  const failed = tonight.filter(t => t.status === 'failed');
+  const pending = tasks.filter(t => t.status === 'pending');
+
+  let md = `# AutoClaude Overnight Summary\n\n`;
+  md += `**Date:** ${new Date().toLocaleDateString()}\n`;
+  md += `**Session start:** ${sessionStartTime.toISOString()}\n`;
+  md += `**Summary generated:** ${new Date().toISOString()}\n\n`;
+  md += `## Results: ${completed.length} completed, ${failed.length} failed, ${pending.length} still pending\n\n`;
+
+  for (const task of tonight) {
+    const icon = task.status === 'completed' ? 'DONE' : 'FAIL';
+    md += `### [${icon}] ${task.title}\n`;
+    md += `- **Directory:** ${task.dir}\n`;
+    md += `- **Duration:** ${formatDuration(task.started, task.completed)}\n`;
+    md += `- **Session:** \`${task.sessionId}\`\n`;
+    md += `- **Permission Profile:** ${task.permissionProfile}\n`;
+    md += `- **Sub-agent Level:** ${Math.round((task.subagentLevel || 0) * 100)}%\n`;
+
+    if (task.stats) {
+      md += `\n**Work Distribution:**\n`;
+      md += `- Claude direct tool uses: ${task.stats.claudeDirectWork}\n`;
+      md += `- Sub-agent calls: ${task.stats.subagentCount}\n`;
+      md += `- Sub-agent ratio: ${Math.round(task.stats.subagentRatio * 100)}%\n`;
+      md += `- Models used: ${task.stats.models?.join(', ') || 'unknown'}\n`;
+
+      if (task.stats.subagentCalls?.length) {
+        md += `\n**Sub-agents spawned:**\n`;
+        for (const sa of task.stats.subagentCalls) {
+          md += `  - [${sa.subagentType}] ${sa.description} (model: ${sa.model})\n`;
+        }
+      }
+
+      if (task.stats.toolUses) {
+        md += `\n**Tool usage breakdown:**\n`;
+        for (const [tool, count] of Object.entries(task.stats.toolUses).sort((a, b) => b[1] - a[1])) {
+          md += `  - ${tool}: ${count}\n`;
+        }
+      }
+    }
+
+    if (task.sessionId) {
+      const todos = getSessionTodos(task.sessionId);
+      if (todos.length > 0) {
+        md += `\n**Todo items:**\n`;
+        for (const todo of todos) {
+          const check = todo.status === 'completed' ? 'x' : ' ';
+          md += `  - [${check}] ${todo.content}\n`;
+        }
+      }
+    }
+
+    if (task.error) {
+      md += `\n**Error:** ${task.error}\n`;
+    }
+    md += '\n---\n\n';
+  }
+
+  const filename = `summary-${new Date().toISOString().slice(0, 10)}.md`;
+  const summaryPath = join(config.paths.summaryDir, filename);
+  writeFileSync(summaryPath, md);
+
+  return { path: summaryPath, content: md };
+}
+
+function formatDuration(start, end) {
+  if (!start || !end) return 'unknown';
+  const ms = new Date(end) - new Date(start);
+  const mins = Math.floor(ms / 60000);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+export function getLatestSummary() {
+  const config = loadConfig();
+  if (!existsSync(config.paths.summaryDir)) return null;
+  const files = readdirSync(config.paths.summaryDir).sort().reverse();
+  if (files.length === 0) return null;
+  return readFileSync(join(config.paths.summaryDir, files[0]), 'utf8');
+}

--- a/packages/store/task-queue.mjs
+++ b/packages/store/task-queue.mjs
@@ -1,0 +1,163 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { loadConfig } from '@autoclaude/core';
+
+// ─── Tasks ───
+
+export function loadTasks() {
+  const config = loadConfig();
+  if (!existsSync(config.paths.taskFile)) return [];
+  try {
+    return JSON.parse(readFileSync(config.paths.taskFile, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+export function saveTasks(tasks) {
+  const config = loadConfig();
+  writeFileSync(config.paths.taskFile, JSON.stringify(tasks, null, 2));
+}
+
+export function createTask({ title, prompt, dir, project = null, dependencies = [], permissionProfile = 'full-auto', subagentLevel = 0.5 }) {
+  const tasks = loadTasks();
+  const maxOrder = tasks.reduce((max, t) => Math.max(max, t.order || 0), 0);
+  const task = {
+    id: randomUUID(),
+    title,
+    prompt,
+    dir: dir || process.cwd(),
+    project,
+    dependencies,
+    status: 'pending',
+    approved: false,
+    order: maxOrder + 1,
+    permissionProfile,
+    subagentLevel,
+    added: new Date().toISOString(),
+    started: null,
+    completed: null,
+    sessionId: null,
+    error: null,
+    stats: null, // populated on completion: { toolUses, subagentCalls, models, duration }
+  };
+  tasks.push(task);
+  saveTasks(tasks);
+  return task;
+}
+
+export function updateTask(id, updates) {
+  const tasks = loadTasks();
+  const idx = tasks.findIndex(t => t.id === id);
+  if (idx === -1) return null;
+  Object.assign(tasks[idx], updates);
+  saveTasks(tasks);
+  return tasks[idx];
+}
+
+export function deleteTask(id) {
+  const tasks = loadTasks();
+  const idx = tasks.findIndex(t => t.id === id);
+  if (idx === -1) return false;
+  tasks.splice(idx, 1);
+  saveTasks(tasks);
+  return true;
+}
+
+export function reorderTasks(orderedIds) {
+  const tasks = loadTasks();
+  for (let i = 0; i < orderedIds.length; i++) {
+    const task = tasks.find(t => t.id === orderedIds[i]);
+    if (task) task.order = i + 1;
+  }
+  saveTasks(tasks);
+  return tasks;
+}
+
+export function getNextApprovedTask() {
+  const tasks = loadTasks();
+  return tasks
+    .filter(t => t.approved && t.status === 'pending')
+    .sort((a, b) => (a.order || 0) - (b.order || 0))[0] || null;
+}
+
+// ─── Permission Profiles ───
+
+export function loadPermissions() {
+  const config = loadConfig();
+  if (!existsSync(config.paths.permissionsFile)) {
+    const defaults = getDefaultPermissions();
+    savePermissions(defaults);
+    return defaults;
+  }
+  try {
+    return JSON.parse(readFileSync(config.paths.permissionsFile, 'utf8'));
+  } catch {
+    return getDefaultPermissions();
+  }
+}
+
+export function savePermissions(data) {
+  const config = loadConfig();
+  writeFileSync(config.paths.permissionsFile, JSON.stringify(data, null, 2));
+}
+
+export function getPermissionProfile(key) {
+  const data = loadPermissions();
+  return data.profiles?.[key] || null;
+}
+
+export function createPermissionProfile(key, profile) {
+  const data = loadPermissions();
+  if (!data.profiles) data.profiles = {};
+  data.profiles[key] = profile;
+  savePermissions(data);
+  return profile;
+}
+
+export function updatePermissionProfile(key, updates) {
+  const data = loadPermissions();
+  if (!data.profiles?.[key]) return null;
+  Object.assign(data.profiles[key], updates);
+  savePermissions(data);
+  return data.profiles[key];
+}
+
+export function deletePermissionProfile(key) {
+  const data = loadPermissions();
+  if (!data.profiles?.[key]) return false;
+  delete data.profiles[key];
+  savePermissions(data);
+  return true;
+}
+
+function getDefaultPermissions() {
+  return {
+    profiles: {
+      'full-auto': {
+        name: 'Full Auto',
+        description: 'Skip all permission checks',
+        permissionMode: 'bypassPermissions',
+        dangerouslySkipPermissions: true,
+        allowedTools: [],
+        disallowedTools: [],
+      },
+      'safe-edit': {
+        name: 'Safe Edit',
+        description: 'Auto-accept file edits only',
+        permissionMode: 'acceptEdits',
+        dangerouslySkipPermissions: false,
+        allowedTools: ['Read', 'Edit', 'Write', 'Glob', 'Grep'],
+        disallowedTools: ['Bash'],
+      },
+      'read-only': {
+        name: 'Read Only',
+        description: 'Research only, no modifications',
+        permissionMode: 'plan',
+        dangerouslySkipPermissions: false,
+        allowedTools: ['Read', 'Glob', 'Grep', 'WebFetch'],
+        disallowedTools: ['Edit', 'Write', 'Bash'],
+      },
+    },
+  };
+}

--- a/packages/store/usage-monitor.mjs
+++ b/packages/store/usage-monitor.mjs
@@ -1,0 +1,124 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { loadConfig } from '@autoclaude/core';
+
+export function loadUsageHistory() {
+  const config = loadConfig();
+  if (!existsSync(config.paths.usageHistoryFile)) return [];
+  try {
+    return JSON.parse(readFileSync(config.paths.usageHistoryFile, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+export function appendUsageEvent(event) {
+  const history = loadUsageHistory();
+  history.push({ ts: new Date().toISOString(), ...event });
+
+  // Keep last 2000 entries to prevent unbounded growth
+  const trimmed = history.slice(-2000);
+
+  const config = loadConfig();
+  writeFileSync(config.paths.usageHistoryFile, JSON.stringify(trimmed, null, 2));
+}
+
+export function recordPoll(usageData) {
+  if (!usageData?.usage) return;
+
+  const fiveHr = usageData.usage.five_hour;
+  const sevenDay = usageData.usage.seven_day;
+  const overage = usageData.overage;
+  const credits = usageData.credits;
+
+  appendUsageEvent({
+    event: 'poll',
+    fiveHr: fiveHr?.utilization ?? null,
+    fiveHrResetAt: fiveHr?.resets_at ?? null,
+    sevenDay: sevenDay?.utilization ?? null,
+    sevenDayResetAt: sevenDay?.resets_at ?? null,
+    sonnet: usageData.usage.seven_day_sonnet?.utilization ?? null,
+    overageUsed: overage?.used_credits ?? null,
+    overageLimit: overage?.monthly_credit_limit ?? null,
+    prepaidBalance: credits?.amount ?? null,
+    currency: credits?.currency ?? overage?.currency ?? null,
+  });
+}
+
+export function recordTaskEvent(eventType, taskTitle) {
+  appendUsageEvent({ event: eventType, task: taskTitle });
+}
+
+// Build data for dashboard SVG graph
+export function getGraphData(hours = 12) {
+  const history = loadUsageHistory();
+  const cutoff = new Date(Date.now() - hours * 3600000).toISOString();
+
+  const recent = history.filter(e => e.ts >= cutoff);
+
+  const polls = recent.filter(e => e.event === 'poll').map(e => ({
+    ts: e.ts,
+    fiveHr: e.fiveHr,
+    sevenDay: e.sevenDay,
+  }));
+
+  const taskEvents = recent.filter(e => e.event === 'task_start' || e.event === 'task_complete').map(e => ({
+    ts: e.ts,
+    event: e.event,
+    task: e.task,
+  }));
+
+  return { polls, taskEvents };
+}
+
+// Get current usage summary for dashboard header
+export function getCurrentUsageSummary(rawUsageData) {
+  if (!rawUsageData?.usage) return null;
+
+  const u = rawUsageData.usage;
+  const result = {
+    fiveHour: {
+      utilization: u.five_hour?.utilization ?? 0,
+      resetsAt: u.five_hour?.resets_at ?? null,
+      resetsIn: u.five_hour?.resets_at ? formatTimeUntil(u.five_hour.resets_at) : null,
+    },
+    sevenDay: {
+      utilization: u.seven_day?.utilization ?? 0,
+      resetsAt: u.seven_day?.resets_at ?? null,
+      resetsIn: u.seven_day?.resets_at ? formatTimeUntil(u.seven_day.resets_at) : null,
+    },
+    sonnet: {
+      utilization: u.seven_day_sonnet?.utilization ?? 0,
+      resetsAt: u.seven_day_sonnet?.resets_at ?? null,
+    },
+  };
+
+  if (rawUsageData.overage) {
+    result.extraUsage = {
+      used: rawUsageData.overage.used_credits,
+      limit: rawUsageData.overage.monthly_credit_limit,
+      currency: rawUsageData.overage.currency,
+      percentage: rawUsageData.overage.monthly_credit_limit > 0
+        ? Math.round((rawUsageData.overage.used_credits / rawUsageData.overage.monthly_credit_limit) * 100)
+        : 0,
+    };
+  }
+
+  if (rawUsageData.credits) {
+    result.prepaid = {
+      amount: rawUsageData.credits.amount,
+      currency: rawUsageData.credits.currency,
+    };
+  }
+
+  return result;
+}
+
+function formatTimeUntil(isoDate) {
+  const diff = new Date(isoDate) - Date.now();
+  if (diff <= 0) return 'now';
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const remainMins = mins % 60;
+  return `${hrs}h ${remainMins}m`;
+}


### PR DESCRIPTION
## Summary

Splits the flat `src/` directory (15 files) into 6 focused npm workspace packages under `packages/`, each with clear boundaries and its own `CLAUDE.md` for agent scoping:

- **@autoclaude/core** — config, logging, notifications, scheduler (foundation, zero deps)
- **@autoclaude/sessions** — macOS Claude Code session scanning (zero deps)
- **@autoclaude/store** — tasks, permissions, projects, usage history, summaries (JSON CRUD)
- **@autoclaude/runner** — task runner + credit monitor (subprocess/API)
- **@autoclaude/server** — HTTP API + single-file dashboard frontend
- **@autoclaude/daemon** — orchestration loop (SLEEP/WAKE/WORK)

Cross-package imports use `@autoclaude/*` via npm workspaces. Zero external dependencies added. All existing functionality verified working — API endpoints, dashboard tabs, task management.

## Changes
- 30 new files across 6 packages (source + package.json + index.mjs + CLAUDE.md each)
- Updated `bin/autoclaude.mjs` imports to use package names
- Updated root `package.json` with npm workspaces config
- Updated root `CLAUDE.md` with new architecture documentation
- Original `src/` files retained for reference (to be removed in follow-up)

## Test plan
- [x] Server starts without errors (`node bin/autoclaude.mjs`)
- [x] All API endpoints return valid data (status, tasks, permissions, projects)
- [x] Dashboard renders correctly (all 5 tabs verified with screenshots)
- [x] No JavaScript console errors
- [x] npm workspaces correctly link all packages
- [x] User tested and approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)